### PR TITLE
feat: sprint management (#78) + sub-task creation (#85)

### DIFF
--- a/.claude/ai-usage-prompt.md
+++ b/.claude/ai-usage-prompt.md
@@ -725,7 +725,6 @@ budjira worklog list ISSUE-KEY
 Display all worklog entries for an issue.
 
 **Output includes:**
-- Worklog ID
 - Author
 - Time spent
 - Started date/time
@@ -734,28 +733,7 @@ Display all worklog entries for an issue.
 **Example:**
 ```bash
 budjira worklog list PROJ-123
-# Shows table with ID, author, time, started, comment
-```
-
-### Delete Worklog Entry
-
-```bash
-budjira worklog delete ISSUE-KEY WORKLOG_ID [OPTIONS]
-```
-
-Delete a native Jira worklog entry by its ID. Use `budjira worklog list` to find worklog IDs.
-
-**Options:**
-- `--force`, `-f`: Skip confirmation prompt
-- `--connection`, `-c`: Connection to use
-
-**Examples:**
-```bash
-# Delete with confirmation (shows worklog details first)
-budjira worklog delete PROJ-123 12345
-
-# Delete without confirmation
-budjira worklog delete PROJ-123 12345 --force
+# Shows table of all worklog entries
 ```
 
 ### Time Estimates
@@ -1429,11 +1407,8 @@ budjira issue update PROJ-456 --remaining-estimate 6h
 # 4. Log more work
 budjira worklog add PROJ-456 3h --comment "Implemented core functionality"
 
-# 5. View all logged time (shows worklog IDs)
+# 5. View all logged time
 budjira worklog list PROJ-456
-
-# 5b. Delete wrong worklog entry
-budjira worklog delete PROJ-456 12345 --force
 
 # 6. Final work log and complete
 budjira issue update PROJ-456 \

--- a/.claude/context.md
+++ b/.claude/context.md
@@ -279,10 +279,10 @@ budjira/services/
 
 | Metrik | Wert |
 |--------|------|
-| **Total Tests** | 794 |
+| **Total Tests** | 833 |
 | **Skipped Tests** | 3 |
-| **Coverage** | 85.93% |
-| **Test Duration** | ~17s |
+| **Coverage** | 85.67% |
+| **Test Duration** | ~15s |
 
 ### Coverage by Module (Top)
 ```
@@ -317,7 +317,8 @@ budjira/tempo/client.py        90%
 - **#73** - Auto-discover Jira project metadata → Released v1.19.0
 
 ### In Progress / Open
-- **#74** - Local-first release workflow (in Planung)
+- **#78** - Sprint move + lifecycle (move/create/start/close) → implementiert, Release ausstehend
+- **#74** - Local-first release workflow → erledigt (v1.20.0, cz bump)
 - **#75** - AI prompt optimization (nicht gestartet)
 
 ### Refactoring-Backlog (39 Issues)
@@ -431,6 +432,7 @@ budjira/
 | Issue Delete | v1.15.0 | `budjira issue delete` |
 | Workflow Profiles | v1.16.0 | `budjira workflow *` |
 | Sprint Querying | v1.17.0 | `budjira sprint list`, `sprint show` |
+| Sprint Management | pending | `budjira sprint move/create/start/close` |
 | Workflow Sprint | v1.17.0 | `budjira workflow sprint` |
 | Booking Policy Enforcement | v1.17.0 | `budjira tempo log` (workflow) |
 | Cross-instance Tempo Fix | v1.18.1 | `budjira workflow book` |

--- a/.claude/context.md
+++ b/.claude/context.md
@@ -317,6 +317,7 @@ budjira/tempo/client.py        90%
 - **#73** - Auto-discover Jira project metadata → Released v1.19.0
 
 ### In Progress / Open
+- **#85** - Sub-task creation via `--parent` → implementiert, Release ausstehend (blockierte Epic>Story>Sub-task-Buchung)
 - **#78** - Sprint move + lifecycle (move/create/start/close) → implementiert, Release ausstehend
 - **#74** - Local-first release workflow → erledigt (v1.20.0, cz bump)
 - **#75** - AI prompt optimization (nicht gestartet)
@@ -433,6 +434,7 @@ budjira/
 | Workflow Profiles | v1.16.0 | `budjira workflow *` |
 | Sprint Querying | v1.17.0 | `budjira sprint list`, `sprint show` |
 | Sprint Management | pending | `budjira sprint move/create/start/close` |
+| Sub-task Creation | pending | `budjira create issue --type Subtask --parent KEY` |
 | Workflow Sprint | v1.17.0 | `budjira workflow sprint` |
 | Booking Policy Enforcement | v1.17.0 | `budjira tempo log` (workflow) |
 | Cross-instance Tempo Fix | v1.18.1 | `budjira workflow book` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -344,6 +344,22 @@ Use `uv run cz commit` for interactive commit creation.
 
 **If hooks fail, the commit is rejected.** Fix issues before committing.
 
+**Hooks must never write files (check-only rule):** pre-commit stashes unstaged
+changes for the duration of a commit. A hook that *modifies and stages* a file
+which also has stashed unstaged changes makes pre-commit's stash restore fail
+(`patch does not apply`), silently stranding your work in a backup patch under
+`~/.cache/pre-commit/`. The `check-ai-prompt-freshness` hook (`scripts/check_ai_prompt.py`)
+therefore only *detects* staleness and prints a reminder — it does **not**
+regenerate `.claude/ai-usage-prompt.md`. Regenerate that file manually and commit
+it separately:
+
+```bash
+uv run budjira -q ai usage-prompt --plain > .claude/ai-usage-prompt.md
+```
+
+If you add a new hook, keep it check-only (validate and fail with a message);
+never have it rewrite tracked files in place.
+
 ### CI/CD Pipeline Consistency
 
 **Critical:** CI and pre-commit hooks are perfectly synchronized to ensure "if pre-commit passes locally → CI passes" ✅

--- a/README.md
+++ b/README.md
@@ -362,7 +362,39 @@ budjira --format json epic show PROJ-100
 - **Time Analysis**: Analyze time tracking data for effort estimation
 - **Automation**: Use in CI/CD pipelines or scripts
 
-### 9. Check for Updates
+### 9. Manage Sprints
+
+Query sprints, move issues between them, and drive the sprint lifecycle from
+the CLI. The board is auto-detected (or set `board_id` in `connections.toml`).
+
+```bash
+# List sprints (optionally filter by state)
+budjira sprint list
+budjira sprint list --state active
+
+# Show the contents of a sprint (defaults to the active sprint)
+budjira sprint show
+budjira sprint show "Sprint 42" --mine
+
+# Move issues into a sprint (by name or ID)
+budjira sprint move PROJ-1 PROJ-2 --to "Sprint 42"
+budjira sprint move PROJ-123 --sprint-id 100
+
+# Create a new (future) sprint; dates are optional
+budjira sprint create "Sprint 43" --start today --end 2026-06-14 --goal "Ship the API"
+
+# Start a sprint (requires start + end dates)
+budjira sprint start "Sprint 43" --start today --end 2026-06-14
+
+# Close a sprint (defaults to the active sprint)
+budjira sprint close --force
+```
+
+> **Note:** Creating, starting, and closing sprints requires Jira board-admin
+> permissions. `move` only needs permission to edit the issues. `start` and
+> `close` ask for confirmation unless you pass `--force`.
+
+### 10. Check for Updates
 
 budjira automatically checks for updates every 24 hours and notifies you when a new version is available.
 
@@ -397,7 +429,7 @@ source ~/.bashrc
 
 **Why?** Unauthenticated requests are limited to 60/hour. Authenticated requests get 5,000/hour.
 
-### 10. AI Integration
+### 11. AI Integration
 
 Generate comprehensive usage guides for AI assistants.
 

--- a/README.md
+++ b/README.md
@@ -212,6 +212,9 @@ budjira create issue "User authentication" --type Story --epic PROJ-100
 budjira create issue "Story 1" --type Story --epic PROJ-100 --no-interactive
 budjira create issue "Story 2" --type Story --epic PROJ-100 --no-interactive
 budjira create issue "Story 3" --type Story --epic PROJ-100 --no-interactive
+
+# Create a sub-task under a parent issue
+budjira create issue "Implement login form" --type Subtask --parent PROJ-123 --no-interactive
 ```
 
 **Epic Linking:**
@@ -219,6 +222,13 @@ budjira create issue "Story 3" --type Story --epic PROJ-100 --no-interactive
 - Eliminates need for separate update step
 - Perfect for creating multiple stories for same epic
 - Works in both interactive and non-interactive modes
+
+**Sub-tasks:**
+- Use `--parent PROJ-123` to create a sub-task under a parent issue
+- The sub-task type name differs per instance (`Subtask` or `Sub-task`); budjira
+  detects sub-task types from cached project metadata (`budjira project show`)
+- Creating a sub-task without `--parent` fails fast with a clear error instead of a
+  cryptic Jira API response
 
 ### 6. Definition of Ready (DoR) Templates
 

--- a/budjira/cli/create.py
+++ b/budjira/cli/create.py
@@ -207,6 +207,50 @@ def _get_epic_input(interactive: bool, epic: str | None) -> str | None:
     return epic
 
 
+def _is_subtask_type(issue_type: str, metadata: ProjectMetadata | None) -> bool:
+    """Determine whether an issue type is a sub-task type.
+
+    Prefers the authoritative ``subtask`` flag from project metadata, which is
+    robust to naming differences between instances (e.g. 'Subtask' vs
+    'Sub-task'). Falls back to a normalized name heuristic when metadata is
+    unavailable.
+
+    Args:
+        issue_type: Issue type name as entered by the user
+        metadata: Cached project metadata, if available
+
+    Returns:
+        True if the issue type represents a sub-task
+    """
+    if metadata:
+        for it in metadata.issue_types:
+            if it.name.lower() == issue_type.lower():
+                return it.subtask
+    return issue_type.lower().replace("-", "").replace(" ", "") == "subtask"
+
+
+def _get_parent_input(
+    interactive: bool,
+    parent: str | None,
+    issue_type: str,
+    metadata: ProjectMetadata | None,
+) -> str | None:
+    """Prompt for a parent issue key when creating a sub-task without one.
+
+    Args:
+        interactive: Whether to prompt interactively
+        parent: Pre-provided parent issue key
+        issue_type: Resolved issue type
+        metadata: Cached project metadata, if available
+
+    Returns:
+        Parent issue key or None
+    """
+    if parent is None and interactive and _is_subtask_type(issue_type, metadata):
+        return str(Prompt.ask("Parent issue key (required for sub-tasks, e.g., PROJ-123)"))
+    return parent
+
+
 def _parse_custom_fields(
     custom_args: list[str] | None,
     custom_field_configs: dict[str, CustomFieldConfig],
@@ -407,6 +451,27 @@ def _validate_required_fields(summary: str, issue_type: str) -> None:
         raise typer.Exit(1)
 
 
+def _validate_parent(parent: str | None, issue_type: str, metadata: ProjectMetadata | None) -> None:
+    """Validate that sub-task creation has a parent issue.
+
+    Fails fast with an actionable message instead of letting Jira reject the
+    request with the cryptic "parent issue key or id not specified" error.
+
+    Args:
+        parent: Parent issue key, if provided
+        issue_type: Resolved issue type
+        metadata: Cached project metadata, if available
+
+    Raises:
+        BudjiraError: If a sub-task is created without a parent
+    """
+    if not parent and _is_subtask_type(issue_type, metadata):
+        raise BudjiraError(
+            f"Issue type '{issue_type}' is a sub-task and requires a parent issue. "
+            f"Provide it with --parent PROJ-123."
+        )
+
+
 def _validate_dor(description: str | None, issue_type: str, skip_dor: bool, settings: Settings) -> None:
     """Validate description against DoR template if enabled.
 
@@ -458,6 +523,18 @@ def _prepare_time_tracking(original_estimate: str | None, remaining_estimate: st
             timetracking["remainingEstimate"] = remaining_estimate
         extra_fields["timetracking"] = timetracking
     return extra_fields
+
+
+def _prepare_parent_field(parent: str | None) -> dict[str, Any]:
+    """Prepare the parent field for sub-task creation.
+
+    Args:
+        parent: Parent issue key (e.g., PROJ-123)
+
+    Returns:
+        Dictionary with the Jira parent field, or empty if no parent
+    """
+    return {"parent": {"key": parent}} if parent else {}
 
 
 def _link_to_epic_if_specified(client: JiraClient, issue_key: str, epic: str | None) -> str | None:
@@ -611,6 +688,11 @@ def issue(
         "-e",
         help="Epic key to link this issue to (e.g., PROJ-100)",
     ),
+    parent: str = typer.Option(
+        None,
+        "--parent",
+        help="Parent issue key for sub-tasks (e.g., PROJ-123)",
+    ),
     custom: list[str] = typer.Option(
         None,
         "--custom",
@@ -635,6 +717,9 @@ def issue(
 
         # Link to epic during creation
         budjira create issue "User authentication" --type Story --epic PROJ-100
+
+        # Create a sub-task under a parent issue
+        budjira create issue "Implement login form" --type Subtask --parent PROJ-123 --no-interactive
 
         # Create multiple stories for same epic
         budjira create issue "Story 1" --type Story --epic PROJ-100 --no-interactive
@@ -664,6 +749,7 @@ def issue(
         assignee = _get_assignee_input(interactive, assignee)  # type: ignore[assignment]
         labels = _get_labels_input(interactive, labels)
         epic = _get_epic_input(interactive, epic)  # type: ignore[assignment]
+        parent = _get_parent_input(interactive, parent, issue_type, project_metadata)  # type: ignore[assignment]
 
         # Handle custom fields
         custom_values = _parse_custom_fields(custom, custom_field_configs)
@@ -674,6 +760,7 @@ def issue(
 
         # Validate
         _validate_required_fields(summary, issue_type)
+        _validate_parent(parent, issue_type, project_metadata)
         _validate_dor(description, issue_type, skip_dor, settings)
 
         # Create issue
@@ -681,6 +768,9 @@ def issue(
         console.print(f"\n[dim]Creating {issue_type} in project {project_key}...[/dim]")
 
         extra_fields = _prepare_time_tracking(original_estimate, remaining_estimate)
+
+        # Add parent field for sub-tasks
+        extra_fields.update(_prepare_parent_field(parent))
 
         # Add custom fields to extra_fields
         if custom_values and custom_field_configs:

--- a/budjira/cli/create.py
+++ b/budjira/cli/create.py
@@ -121,7 +121,7 @@ def _get_description_input(
 
     if use_dor:
         template = settings.dor_templates.get_template(issue_type or "")
-        if template and Confirm.ask(f"Use DoR template for {issue_type}?", default=True):
+        if template is not None and Confirm.ask(f"Use DoR template for {issue_type}?", default=True):
             console.print(f"\n[dim]Opening editor with DoR template for {issue_type}...[/dim]")
             return open_editor(
                 initial_content=template.template_text,

--- a/budjira/cli/sprint.py
+++ b/budjira/cli/sprint.py
@@ -11,6 +11,7 @@ from rich.table import Table
 from budjira.core.jira_client import JiraClient
 from budjira.models.sprint import Sprint, SprintState
 from budjira.utils.connection import get_active_connection
+from budjira.utils.datetime_parser import parse_datetime_string
 from budjira.utils.errors import BudjiraError
 from budjira.utils.formatter import OutputFormatter
 
@@ -75,6 +76,46 @@ def _resolve_sprint(
             f"No active sprint found on board {board_id}. Specify a sprint name or use --state to filter."
         )
     return active
+
+
+def _resolve_target(
+    client: JiraClient,
+    board_id: int,
+    sprint_name: str | None,
+    sprint_id: int | None,
+    allow_active: bool,
+) -> Sprint:
+    """Resolve a target sprint by ID, name, or (optionally) the active sprint.
+
+    Args:
+        client: Jira client
+        board_id: Board ID (used for name lookup / active sprint)
+        sprint_id: Explicit sprint ID (highest priority)
+        sprint_name: Sprint name (case-insensitive partial match)
+        allow_active: If True and neither id nor name given, fall back to the
+            active sprint; otherwise require an explicit target
+
+    Returns:
+        Resolved Sprint
+
+    Raises:
+        BudjiraError: If no target can be resolved
+    """
+    if sprint_id is not None:
+        return client.sprints.get_sprint(sprint_id)
+    if sprint_name:
+        return client.sprints.find_sprint_by_name(board_id, sprint_name)
+    if allow_active:
+        return _resolve_sprint(client, board_id, None)
+    raise BudjiraError("No sprint specified. Provide a sprint name or use --sprint-id.")
+
+
+def _emit_error(ctx: typer.Context, error: BudjiraError) -> None:
+    """Render a BudjiraError respecting the active output format."""
+    if OutputFormatter.is_json_format(ctx.obj.get("format", "table") if ctx.obj else "table"):
+        OutputFormatter.output_json({"error": str(error)})
+    else:
+        console.print(f"[red]Error:[/red] {error}")
 
 
 @app.command("list")
@@ -169,10 +210,7 @@ def sprint_list(
         console.print(table)
 
     except BudjiraError as e:
-        if OutputFormatter.is_json_format(ctx.obj.get("format", "table") if ctx.obj else "table"):
-            OutputFormatter.output_json({"error": str(e)})
-        else:
-            console.print(f"[red]Error:[/red] {e}")
+        _emit_error(ctx, e)
         raise typer.Exit(1) from e
 
 
@@ -313,8 +351,293 @@ def sprint_show(
         console.print(table)
 
     except BudjiraError as e:
-        if OutputFormatter.is_json_format(ctx.obj.get("format", "table") if ctx.obj else "table"):
-            OutputFormatter.output_json({"error": str(e)})
-        else:
-            console.print(f"[red]Error:[/red] {e}")
+        _emit_error(ctx, e)
+        raise typer.Exit(1) from e
+
+
+def _sprint_result(sprint: Sprint) -> dict[str, object]:
+    """Build a JSON-serializable result dict for a sprint write operation."""
+    return {
+        "id": sprint.id,
+        "name": sprint.name,
+        "state": sprint.state.value,
+        "start_date": sprint.start_date.isoformat() if sprint.start_date else None,
+        "end_date": sprint.end_date.isoformat() if sprint.end_date else None,
+        "board_id": sprint.board_id,
+    }
+
+
+@app.command("move")
+def sprint_move(
+    ctx: typer.Context,
+    issue_keys: Annotated[
+        list[str],
+        typer.Argument(help="One or more issue keys to move (e.g., PROJ-1 PROJ-2)"),
+    ],
+    to: Annotated[
+        str | None,
+        typer.Option("--to", "-t", help="Target sprint name (case-insensitive)"),
+    ] = None,
+    sprint_id: Annotated[
+        int | None,
+        typer.Option("--sprint-id", help="Target sprint ID (alternative to --to)"),
+    ] = None,
+    board: Annotated[
+        int | None,
+        typer.Option("--board", "-b", help="Board ID (auto-detected if not provided)"),
+    ] = None,
+    connection: Annotated[
+        str | None,
+        typer.Option("--connection", "-c", help="Connection name"),
+    ] = None,
+) -> None:
+    """Move issues into a sprint.
+
+    Assigns one or more issues to a target sprint, identified by name (--to)
+    or ID (--sprint-id). The operation is additive (no confirmation needed).
+
+    Examples:
+
+        budjira sprint move PROJ-123 --to "Sprint 42"
+        budjira sprint move PROJ-1 PROJ-2 PROJ-3 --to "Sprint 42"
+        budjira sprint move PROJ-123 --sprint-id 100
+    """
+    try:
+        output_format = ctx.obj.get("format", "table") if ctx.obj else "table"
+        is_json = OutputFormatter.is_json_format(output_format)
+
+        if to is None and sprint_id is None:
+            raise BudjiraError("Specify a target sprint with --to NAME or --sprint-id ID.")
+
+        conn = get_active_connection(connection)
+        if not is_json:
+            console.print(f"[dim]Using connection: {conn.name}[/dim]\n")
+
+        client = JiraClient.from_connection(conn)
+        board_id = _resolve_board_id(client, board, conn.board_id, conn.project_key)
+        sprint = _resolve_target(client, board_id, to, sprint_id, allow_active=False)
+
+        client.sprints.move_issues(sprint.id, issue_keys)
+
+        if is_json:
+            OutputFormatter.output_json(
+                {"moved": issue_keys, "sprint": _sprint_result(sprint)},
+            )
+            return
+
+        moved = ", ".join(issue_keys)
+        console.print(f"[green]Moved {len(issue_keys)} issue(s) into '{sprint.name}':[/green] {moved}")
+
+    except BudjiraError as e:
+        _emit_error(ctx, e)
+        raise typer.Exit(1) from e
+
+
+@app.command("create")
+def sprint_create(
+    ctx: typer.Context,
+    name: Annotated[str, typer.Argument(help="Sprint name")],
+    start: Annotated[
+        str | None,
+        typer.Option("--start", help="Start date (ISO, 'today', 'yesterday')"),
+    ] = None,
+    end: Annotated[
+        str | None,
+        typer.Option("--end", help="End date (ISO, 'today', 'yesterday')"),
+    ] = None,
+    goal: Annotated[
+        str | None,
+        typer.Option("--goal", "-g", help="Sprint goal"),
+    ] = None,
+    board: Annotated[
+        int | None,
+        typer.Option("--board", "-b", help="Board ID (auto-detected if not provided)"),
+    ] = None,
+    connection: Annotated[
+        str | None,
+        typer.Option("--connection", "-c", help="Connection name"),
+    ] = None,
+) -> None:
+    """Create a new (future) sprint on a board.
+
+    Dates are optional and can be set later when starting the sprint.
+
+    Examples:
+
+        budjira sprint create "Sprint 43"
+        budjira sprint create "Sprint 43" --start today --end 2026-06-14
+        budjira sprint create "Sprint 43" --goal "Ship the API"
+    """
+    try:
+        output_format = ctx.obj.get("format", "table") if ctx.obj else "table"
+        is_json = OutputFormatter.is_json_format(output_format)
+
+        conn = get_active_connection(connection)
+        if not is_json:
+            console.print(f"[dim]Using connection: {conn.name}[/dim]\n")
+
+        client = JiraClient.from_connection(conn)
+        board_id = _resolve_board_id(client, board, conn.board_id, conn.project_key)
+
+        start_dt = parse_datetime_string(start, allow_future=True) if start else None
+        end_dt = parse_datetime_string(end, allow_future=True) if end else None
+
+        sprint = client.sprints.create_sprint(
+            board_id=board_id,
+            name=name,
+            start_date=start_dt,
+            end_date=end_dt,
+            goal=goal,
+        )
+
+        if is_json:
+            OutputFormatter.output_json(_sprint_result(sprint))
+            return
+
+        console.print(f"[green]Created sprint '{sprint.name}' (ID: {sprint.id}) on board {board_id}.[/green]")
+
+    except BudjiraError as e:
+        _emit_error(ctx, e)
+        raise typer.Exit(1) from e
+
+
+@app.command("start")
+def sprint_start(
+    ctx: typer.Context,
+    sprint_name: Annotated[
+        str | None,
+        typer.Argument(help="Sprint name to start"),
+    ] = None,
+    sprint_id: Annotated[
+        int | None,
+        typer.Option("--sprint-id", help="Sprint ID (alternative to name)"),
+    ] = None,
+    start: Annotated[
+        str | None,
+        typer.Option("--start", help="Start date (required if the sprint has none)"),
+    ] = None,
+    end: Annotated[
+        str | None,
+        typer.Option("--end", help="End date (required if the sprint has none)"),
+    ] = None,
+    force: Annotated[
+        bool,
+        typer.Option("--force", "-f", help="Skip confirmation prompt"),
+    ] = False,
+    board: Annotated[
+        int | None,
+        typer.Option("--board", "-b", help="Board ID (auto-detected if not provided)"),
+    ] = None,
+    connection: Annotated[
+        str | None,
+        typer.Option("--connection", "-c", help="Connection name"),
+    ] = None,
+) -> None:
+    """Start a sprint (transition it to the active state).
+
+    Jira requires the sprint to have a start and end date. Provide --start and
+    --end if the sprint does not have them yet.
+
+    Examples:
+
+        budjira sprint start "Sprint 43" --start today --end 2026-06-14
+        budjira sprint start --sprint-id 100 --force
+    """
+    try:
+        output_format = ctx.obj.get("format", "table") if ctx.obj else "table"
+        is_json = OutputFormatter.is_json_format(output_format)
+
+        conn = get_active_connection(connection)
+        if not is_json:
+            console.print(f"[dim]Using connection: {conn.name}[/dim]\n")
+
+        client = JiraClient.from_connection(conn)
+        board_id = _resolve_board_id(client, board, conn.board_id, conn.project_key)
+        sprint = _resolve_target(client, board_id, sprint_name, sprint_id, allow_active=False)
+
+        if not force:
+            if is_json:
+                raise BudjiraError("Confirmation required. Re-run with --force in JSON mode.")
+            if not typer.confirm(f"Start sprint '{sprint.name}' (ID: {sprint.id})?"):
+                console.print("[yellow]Aborted.[/yellow]")
+                raise typer.Exit(0)
+
+        start_dt = parse_datetime_string(start, allow_future=True) if start else None
+        end_dt = parse_datetime_string(end, allow_future=True) if end else None
+        updated = client.sprints.start_sprint(sprint.id, start_date=start_dt, end_date=end_dt)
+
+        if is_json:
+            OutputFormatter.output_json(_sprint_result(updated))
+            return
+
+        console.print(f"[green]Started sprint '{updated.name}' (ID: {updated.id}).[/green]")
+
+    except BudjiraError as e:
+        _emit_error(ctx, e)
+        raise typer.Exit(1) from e
+
+
+@app.command("close")
+def sprint_close(
+    ctx: typer.Context,
+    sprint_name: Annotated[
+        str | None,
+        typer.Argument(help="Sprint name to close (default: active sprint)"),
+    ] = None,
+    sprint_id: Annotated[
+        int | None,
+        typer.Option("--sprint-id", help="Sprint ID (alternative to name)"),
+    ] = None,
+    force: Annotated[
+        bool,
+        typer.Option("--force", "-f", help="Skip confirmation prompt"),
+    ] = False,
+    board: Annotated[
+        int | None,
+        typer.Option("--board", "-b", help="Board ID (auto-detected if not provided)"),
+    ] = None,
+    connection: Annotated[
+        str | None,
+        typer.Option("--connection", "-c", help="Connection name"),
+    ] = None,
+) -> None:
+    """Close a sprint (transition it to the closed state).
+
+    Defaults to the active sprint when no name or ID is given.
+
+    Examples:
+
+        budjira sprint close
+        budjira sprint close "Sprint 42"
+        budjira sprint close --sprint-id 100 --force
+    """
+    try:
+        output_format = ctx.obj.get("format", "table") if ctx.obj else "table"
+        is_json = OutputFormatter.is_json_format(output_format)
+
+        conn = get_active_connection(connection)
+        if not is_json:
+            console.print(f"[dim]Using connection: {conn.name}[/dim]\n")
+
+        client = JiraClient.from_connection(conn)
+        board_id = _resolve_board_id(client, board, conn.board_id, conn.project_key)
+        sprint = _resolve_target(client, board_id, sprint_name, sprint_id, allow_active=True)
+
+        if not force:
+            if is_json:
+                raise BudjiraError("Confirmation required. Re-run with --force in JSON mode.")
+            if not typer.confirm(f"Close sprint '{sprint.name}' (ID: {sprint.id})?"):
+                console.print("[yellow]Aborted.[/yellow]")
+                raise typer.Exit(0)
+
+        updated = client.sprints.close_sprint(sprint.id)
+
+        if is_json:
+            OutputFormatter.output_json(_sprint_result(updated))
+            return
+
+        console.print(f"[green]Closed sprint '{updated.name}' (ID: {updated.id}).[/green]")
+
+    except BudjiraError as e:
+        _emit_error(ctx, e)
         raise typer.Exit(1) from e

--- a/budjira/models/ai_prompt.py
+++ b/budjira/models/ai_prompt.py
@@ -465,7 +465,13 @@ budjira create issue "Issue summary" --no-interactive [OPTIONS]
 - `--label TAG`: Add label (can be used multiple times)
 - `--project KEY`: Override default project
 - `--epic KEY`: Link to epic during creation
+- `--parent KEY`: Parent issue key for sub-tasks (required when the type is a sub-task)
 - `--custom NAME=VALUE`: Set custom field (repeatable, requires configuration)
+
+**Sub-tasks:** Use `--parent PROJ-123` to create a sub-task under a parent issue.
+The sub-task type name varies per instance (often `Subtask`, sometimes `Sub-task`);
+budjira detects sub-task types via cached project metadata (`budjira project show`)
+and fails fast with a clear message if a sub-task is created without `--parent`.
 
 **Examples:**
 
@@ -489,6 +495,12 @@ budjira create issue "Add export functionality" \\
 # Quick task creation
 budjira create issue "Update documentation" \\
   --type Task \\
+  --no-interactive
+
+# Sub-task under a parent issue (Epic > Story > Sub-task workflows)
+budjira create issue "Implement login form" \\
+  --type Subtask \\
+  --parent PROJ-123 \\
   --no-interactive
 
 # With custom fields (requires configuration in connections.toml)

--- a/budjira/models/ai_prompt.py
+++ b/budjira/models/ai_prompt.py
@@ -1334,6 +1334,36 @@ budjira --format json sprint show
 - Sprint header with name, state, and dates
 - Table of issues with: Key, Type, Status, Priority, Summary, Assignee
 
+### Sprint Management (Write Operations)
+
+Move issues into sprints and manage the sprint lifecycle. Lifecycle and
+delete operations require Jira board-admin permissions; a 403 is reported as
+a permission error.
+
+```bash
+# Move one or more issues into a sprint (by name or ID)
+budjira sprint move ISSUE-KEY [ISSUE-KEY ...] --to "Sprint 42"
+budjira sprint move PROJ-1 PROJ-2 --sprint-id 100
+
+# Create a new (future) sprint; dates are optional
+budjira sprint create "Sprint 43"
+budjira sprint create "Sprint 43" --start today --end 2026-06-14 --goal "Ship the API"
+
+# Start a sprint (-> active); Jira requires start+end dates
+budjira sprint start "Sprint 43" --start today --end 2026-06-14
+budjira sprint start --sprint-id 100 --force
+
+# Close a sprint (-> closed); defaults to the active sprint
+budjira sprint close
+budjira sprint close "Sprint 42" --force
+```
+
+**Key points:**
+- `move` is additive and needs no confirmation. Target via `--to NAME` or `--sprint-id ID` (one is required).
+- `start`/`close` prompt for confirmation; use `--force`/`-f` to skip. In JSON mode `--force` is mandatory.
+- Sprint dates accept ISO (`2026-06-14`), `today`, `tomorrow`, or `yesterday`.
+- All commands support `--board`, `--connection`, and `--format json`.
+
 ### Board Configuration
 
 The board is resolved in this order:

--- a/budjira/services/issues.py
+++ b/budjira/services/issues.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 from jira.exceptions import JIRAError
 
@@ -218,7 +218,10 @@ class IssueService(BaseJiraService):
         """
         try:
             self._log_operation("Delete issue", issue_key=issue_key, delete_subtasks=delete_subtasks)
-            self.client.issue(issue_key).delete(deleteSubtasks=delete_subtasks)
+            # jira's Resource.delete is inherited untyped (unlike the overridden Issue.update). cast() keeps this
+            # clean across mypy environments: with jira installed the call would otherwise raise no-untyped-call,
+            # while in the jira-less CI mypy env a type: ignore would be flagged unused.
+            cast(Any, self.client.issue(issue_key)).delete(deleteSubtasks=delete_subtasks)
             self._logger.info(f"Deleted issue {issue_key}")
 
         except JIRAError as e:

--- a/budjira/services/sprints.py
+++ b/budjira/services/sprints.py
@@ -8,9 +8,11 @@ from jira.exceptions import JIRAError
 
 from budjira.models.sprint import Board, Sprint, SprintState
 from budjira.services.base import BaseJiraService
-from budjira.utils.errors import JiraAPIError
+from budjira.utils.errors import InvalidIssueError, JiraAPIError, PermissionError
 
 if TYPE_CHECKING:
+    from datetime import datetime
+
     from budjira.models.issue import Issue
 
 
@@ -167,3 +169,195 @@ class SprintService(BaseJiraService):
 
         sprint_list = ", ".join(f"'{s.name}'" for s in matches)
         raise JiraAPIError(f"Multiple sprints match '{name}': {sprint_list}. Please provide a more specific name.")
+
+    def get_sprint(self, sprint_id: int) -> Sprint:
+        """Get a single sprint by ID.
+
+        Args:
+            sprint_id: Sprint ID
+
+        Returns:
+            Sprint object
+
+        Raises:
+            InvalidIssueError: If the sprint does not exist
+            JiraAPIError: If retrieval fails
+        """
+        try:
+            self._log_operation("Get sprint", sprint_id=sprint_id)
+            jira_sprint = self._client.sprint(sprint_id)
+            return Sprint.from_jira_sprint(jira_sprint)
+        except JIRAError as e:
+            if e.status_code == 404:
+                raise InvalidIssueError(
+                    f"Sprint '{sprint_id}' not found. Use 'budjira sprint list' to see available sprints."
+                ) from e
+            self._handle_jira_error(e, "Get sprint", sprint_id=sprint_id)
+            raise
+        except (InvalidIssueError, PermissionError, JiraAPIError):
+            raise
+        except Exception as e:
+            raise JiraAPIError(f"Failed to get sprint {sprint_id}: {e}") from e
+
+    def move_issues(self, sprint_id: int, issue_keys: list[str]) -> None:
+        """Move issues into a sprint.
+
+        Assigns one or more issues to the target sprint. Issues already in
+        another sprint are moved; the operation is additive and does not
+        remove issues from the sprint.
+
+        Args:
+            sprint_id: Target sprint ID
+            issue_keys: Issue keys to move (e.g., ["PROJ-1", "PROJ-2"])
+
+        Raises:
+            InvalidIssueError: If the sprint or an issue does not exist
+            PermissionError: If the user lacks permission to manage sprints
+            JiraAPIError: If the move fails
+        """
+        try:
+            self._log_operation("Move issues to sprint", sprint_id=sprint_id, issue_keys=issue_keys)
+            self._client.add_issues_to_sprint(sprint_id=sprint_id, issue_keys=issue_keys)
+            self._logger.info(f"Moved {len(issue_keys)} issue(s) into sprint {sprint_id}")
+        except JIRAError as e:
+            self._handle_jira_error(e, "Move issues to sprint", sprint_id=sprint_id)
+            raise
+        except (InvalidIssueError, PermissionError, JiraAPIError):
+            raise
+        except Exception as e:
+            raise JiraAPIError(f"Failed to move issues into sprint {sprint_id}: {e}") from e
+
+    def create_sprint(
+        self,
+        board_id: int,
+        name: str,
+        start_date: datetime | None = None,
+        end_date: datetime | None = None,
+        goal: str | None = None,
+    ) -> Sprint:
+        """Create a new sprint on a board.
+
+        The sprint is created in the ``future`` state. Start and end dates are
+        optional; they can be set later when starting the sprint.
+
+        Args:
+            board_id: Board ID to create the sprint on
+            name: Sprint name
+            start_date: Optional planned start date
+            end_date: Optional planned end date
+            goal: Optional sprint goal
+
+        Returns:
+            The created Sprint
+
+        Raises:
+            PermissionError: If the user lacks permission to manage sprints
+            JiraAPIError: If creation fails
+        """
+        try:
+            self._log_operation("Create sprint", board_id=board_id, name=name)
+            jira_sprint = self._client.create_sprint(
+                name=name,
+                board_id=board_id,
+                startDate=start_date.isoformat() if start_date else None,
+                endDate=end_date.isoformat() if end_date else None,
+                goal=goal,
+            )
+            sprint = Sprint.from_jira_sprint(jira_sprint)
+            self._logger.info(f"Created sprint '{name}' (ID: {sprint.id}) on board {board_id}")
+            return sprint
+        except JIRAError as e:
+            self._handle_jira_error(e, "Create sprint", board_id=board_id, name=name)
+            raise
+        except (InvalidIssueError, PermissionError, JiraAPIError):
+            raise
+        except Exception as e:
+            raise JiraAPIError(f"Failed to create sprint '{name}' on board {board_id}: {e}") from e
+
+    def start_sprint(
+        self,
+        sprint_id: int,
+        start_date: datetime | None = None,
+        end_date: datetime | None = None,
+    ) -> Sprint:
+        """Start a sprint (transition to the ``active`` state).
+
+        Jira requires a future sprint to have a start and end date before it
+        can be started. Provide them here if the sprint does not have them set.
+
+        Args:
+            sprint_id: Sprint ID
+            start_date: Optional start date (required if the sprint has none)
+            end_date: Optional end date (required if the sprint has none)
+
+        Returns:
+            The updated Sprint
+
+        Raises:
+            InvalidIssueError: If the sprint does not exist
+            PermissionError: If the user lacks permission to manage sprints
+            JiraAPIError: If the sprint cannot be started
+        """
+        return self._set_state(
+            sprint_id,
+            SprintState.ACTIVE,
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+    def close_sprint(self, sprint_id: int) -> Sprint:
+        """Close a sprint (transition to the ``closed`` state).
+
+        Args:
+            sprint_id: Sprint ID
+
+        Returns:
+            The updated Sprint
+
+        Raises:
+            InvalidIssueError: If the sprint does not exist
+            PermissionError: If the user lacks permission to manage sprints
+            JiraAPIError: If the sprint cannot be closed
+        """
+        return self._set_state(sprint_id, SprintState.CLOSED)
+
+    def _set_state(
+        self,
+        sprint_id: int,
+        state: SprintState,
+        start_date: datetime | None = None,
+        end_date: datetime | None = None,
+    ) -> Sprint:
+        """Transition a sprint to a new state.
+
+        Args:
+            sprint_id: Sprint ID
+            state: Target state
+            start_date: Optional start date (used when starting a sprint)
+            end_date: Optional end date (used when starting a sprint)
+
+        Returns:
+            The updated Sprint (re-fetched after the update)
+
+        Raises:
+            InvalidIssueError: If the sprint does not exist
+            PermissionError: If the user lacks permission to manage sprints
+            JiraAPIError: If the transition fails
+        """
+        try:
+            self._log_operation("Set sprint state", sprint_id=sprint_id, state=state.value)
+            self._client.update_sprint(
+                id=sprint_id,
+                state=state.value,
+                startDate=start_date.isoformat() if start_date else None,
+                endDate=end_date.isoformat() if end_date else None,
+            )
+            self._logger.info(f"Sprint {sprint_id} transitioned to '{state.value}'")
+            return self.get_sprint(sprint_id)
+        except JIRAError as e:
+            self._handle_jira_error(e, "Set sprint state", sprint_id=sprint_id, state=state.value)
+            raise
+        except (InvalidIssueError, PermissionError, JiraAPIError):
+            raise
+        except Exception as e:
+            raise JiraAPIError(f"Failed to set sprint {sprint_id} to '{state.value}': {e}") from e

--- a/budjira/utils/datetime_parser.py
+++ b/budjira/utils/datetime_parser.py
@@ -7,22 +7,25 @@ from datetime import datetime, timedelta
 from budjira.utils.errors import ValidationError
 
 
-def parse_datetime_string(datetime_str: str) -> datetime:
+def parse_datetime_string(datetime_str: str, allow_future: bool = False) -> datetime:
     """Parse a datetime string and return a datetime object.
 
     Supported formats:
     - ISO format: "2025-10-25T14:30:00" or "2025-10-25 14:30:00"
     - Date only: "2025-10-25" (time defaults to 00:00)
-    - Relative: "today", "yesterday"
+    - Relative: "today", "yesterday", "tomorrow"
 
     Args:
         datetime_str: Datetime string to parse
+        allow_future: If True, accept dates in the future (e.g., sprint dates).
+            Defaults to False so worklog timestamps stay in the past.
 
     Returns:
         Parsed datetime object
 
     Raises:
-        ValidationError: If datetime string format is invalid or in the future
+        ValidationError: If datetime string format is invalid, or in the future
+            while ``allow_future`` is False
 
     Examples:
         >>> dt = parse_datetime_string("2025-10-25 14:30")
@@ -43,6 +46,8 @@ def parse_datetime_string(datetime_str: str) -> datetime:
         result = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
     elif datetime_str.lower() == "yesterday":
         result = (datetime.now() - timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
+    elif datetime_str.lower() == "tomorrow":
+        result = (datetime.now() + timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
     else:
         # Try parsing ISO format variants
         formats = [
@@ -68,7 +73,7 @@ def parse_datetime_string(datetime_str: str) -> datetime:
     # Validate: not in the future
     # At this point, result is guaranteed to be a datetime (not None)
     assert result is not None  # nosec B101
-    if result > datetime.now():
+    if not allow_future and result > datetime.now():
         raise ValidationError(f"Datetime cannot be in the future: {result.strftime('%Y-%m-%d %H:%M')}")
 
     return result

--- a/scripts/check_ai_prompt.py
+++ b/scripts/check_ai_prompt.py
@@ -1,26 +1,33 @@
 #!/usr/bin/env python3
-"""Pre-commit hook to regenerate AI prompt documentation.
+"""Pre-commit hook: warn when the AI usage prompt is out of date.
 
-This script checks if CLI command files have been modified and automatically
-regenerates the .claude/ai-usage-prompt.md file to keep it in sync.
+This hook NEVER writes or stages files. Regenerating ``.claude/ai-usage-prompt.md``
+from inside a hook is unsafe: pre-commit stashes unstaged changes for the
+duration of a commit, and a hook that rewrites a file which also has stashed
+unstaged changes makes pre-commit's stash *restore* fail -- it cannot re-apply
+its patch and silently strands the developer's work in a backup patch under
+``~/.cache/pre-commit/``. That is exactly the "wild stasher" data-loss this
+project hit.
 
-Exit codes:
-    0: Success (prompt regenerated)
-    1: Error in script execution
+So this hook only DETECTS staleness and prints an actionable reminder.
+Regeneration stays an explicit, manual step:
+
+    uv run budjira -q ai usage-prompt --plain > .claude/ai-usage-prompt.md
+
+Exit code: always 0 (non-blocking reminder -- never aborts the commit).
 """
 
 import sys
 from pathlib import Path
-from subprocess import run  # nosec B404 - Using subprocess for git/budjira commands (trusted)
+from subprocess import run  # nosec B404 - subprocess for git/budjira commands (trusted)
+
+PROMPT_FILE = Path(".claude/ai-usage-prompt.md")
+REGEN_COMMAND = "uv run budjira -q ai usage-prompt --plain > .claude/ai-usage-prompt.md"
 
 
 def get_staged_files() -> list[str]:
-    """Get list of staged files from git.
-
-    Returns:
-        List of staged file paths
-    """
-    result = run(  # nosec B603 B607 - Running git command with fixed args (safe)
+    """Return the list of staged file paths."""
+    result = run(  # nosec B603 B607 - fixed git args (safe)
         ["git", "diff", "--cached", "--name-only"],
         capture_output=True,
         text=True,
@@ -30,116 +37,65 @@ def get_staged_files() -> list[str]:
 
 
 def check_cli_changes(staged_files: list[str]) -> bool:
-    """Check if any CLI command files were modified.
+    """Return True if a staged change can affect the generated AI prompt."""
+    cli_patterns = ("budjira/cli/", "budjira/models/")
 
-    Args:
-        staged_files: List of staged file paths
-
-    Returns:
-        True if CLI files were modified, False otherwise
-    """
-    cli_patterns = [
-        "budjira/cli/",
-        "budjira/models/",
-    ]
-
-    # Don't regenerate if only the AI prompt itself changed
+    # Ignore a change that only touches the prompt itself.
     non_prompt_changes = [f for f in staged_files if not f.endswith("ai-usage-prompt.md")]
-    if not non_prompt_changes:
-        return False
-
-    for file_path in non_prompt_changes:
-        if any(pattern in file_path for pattern in cli_patterns) and file_path.endswith(".py"):
-            return True
-    return False
+    return any(f.endswith(".py") and any(p in f for p in cli_patterns) for f in non_prompt_changes)
 
 
-def regenerate_ai_prompt() -> bool:
-    """Regenerate the AI usage prompt file.
+def generate_expected_prompt() -> str | None:
+    """Generate the current prompt in memory. Returns None if generation fails."""
+    result = run(  # nosec B603 B607 - controlled command (safe)
+        ["uv", "run", "budjira", "-q", "ai", "usage-prompt", "--plain"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    content = result.stdout
+    return content if content.endswith("\n") else content + "\n"
 
-    Returns:
-        True if successful, False otherwise
-    """
-    try:
-        # Check if .claude directory exists
-        claude_dir = Path(".claude")
-        if not claude_dir.exists():
-            print("⚠️  .claude directory not found, skipping AI prompt regeneration")
-            return True
 
-        prompt_file = claude_dir / "ai-usage-prompt.md"
-
-        print("\n" + "=" * 70)
-        print("🔄 Regenerating AI usage prompt...")
-        print("=" * 70)
-
-        # Run budjira ai usage-prompt --plain
-        result = run(  # nosec B603 B607 - Running controlled command (safe)
-            ["uv", "run", "budjira", "-q", "ai", "usage-prompt", "--plain"],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-
-        if result.returncode != 0:
-            print(f"❌ Failed to generate AI prompt: {result.stderr}")
-            return False
-
-        # Write to file (ensure newline at end)
-        content = result.stdout
-        if not content.endswith("\n"):
-            content += "\n"
-        prompt_file.write_text(content)
-
-        # Stage the updated file
-        run(  # nosec B603 B607 - Running git command (safe)
-            ["git", "add", str(prompt_file)],
-            check=True,
-        )
-
-        print(f"✅ Regenerated and staged {prompt_file}")
-        print()
-        print("The AI usage prompt has been automatically updated to reflect")
-        print("the latest CLI commands and features.")
-        print()
-        print("Please review .claude/ai-prompt-supplements.md if you need to add:")
-        print("  • Project-specific workflows")
-        print("  • Custom examples")
-        print("  • Important tips or caveats")
-        print("=" * 70)
-        print()
-
-        return True
-
-    except Exception as e:
-        print(f"❌ Error regenerating AI prompt: {e}")
-        return False
+def print_reminder() -> None:
+    """Print an actionable reminder that the prompt may be stale."""
+    print("\n" + "=" * 70)
+    print("[i] AI usage prompt may be out of date")
+    print("=" * 70)
+    print("CLI/model files changed but .claude/ai-usage-prompt.md differs from")
+    print("the generated output. Regenerate and stage it in a separate commit:")
+    print()
+    print(f"    {REGEN_COMMAND}")
+    print()
+    print("This hook intentionally does NOT write the file itself (doing so from")
+    print("a hook corrupts pre-commit's stash on partial commits).")
+    print("=" * 70 + "\n")
 
 
 def main() -> int:
-    """Main entry point for the hook.
-
-    Returns:
-        Exit code (0 = success, 1 = error)
-    """
+    """Detect staleness and remind; never modify files, never block the commit."""
     try:
         staged_files = get_staged_files()
-
-        if not staged_files:
-            # No staged files, nothing to check
+        if not staged_files or not check_cli_changes(staged_files):
             return 0
 
-        if check_cli_changes(staged_files) and not regenerate_ai_prompt():
-            # Failed to regenerate, but don't block commit
-            print("⚠️  AI prompt regeneration failed, but commit will proceed")
+        if not PROMPT_FILE.exists():
             return 0
 
-        # Success
+        expected = generate_expected_prompt()
+        if expected is None:
+            # Generation failed -- stay silent rather than nag with a false positive.
+            return 0
+
+        if PROMPT_FILE.read_text() != expected:
+            print_reminder()
+
         return 0
-
     except Exception as e:
-        print(f"Error in AI prompt regeneration: {e}", file=sys.stderr)
-        # Return 0 even on error to not block commits
+        # A reminder hook must never break a commit.
+        print(f"AI prompt freshness check skipped: {e}", file=sys.stderr)
         return 0
 
 

--- a/tests/cli/test_create.py
+++ b/tests/cli/test_create.py
@@ -1488,3 +1488,142 @@ class TestCreateWithProjectMetadata:
 
         assert result.exit_code == 0
         assert "Issue created successfully" in result.stdout
+
+
+class TestIsSubtaskType:
+    """Unit tests for _is_subtask_type helper."""
+
+    def test_metadata_flag_wins(self) -> None:
+        from datetime import datetime, timezone
+
+        from budjira.cli.create import _is_subtask_type
+        from budjira.models.project_metadata import IssueTypeMetadata, ProjectMetadata
+
+        metadata = ProjectMetadata(
+            project_key="TEST",
+            project_name="Test",
+            issue_types=[
+                IssueTypeMetadata(id="1", name="Story", subtask=False),
+                # Instance uses a non-standard label but marks it as a subtask
+                IssueTypeMetadata(id="2", name="Work Item", subtask=True),
+            ],
+            priorities=[],
+            fetched_at=datetime.now(tz=timezone.utc),
+        )
+        assert _is_subtask_type("Work Item", metadata) is True
+        assert _is_subtask_type("Story", metadata) is False
+
+    def test_heuristic_fallback_without_metadata(self) -> None:
+        from budjira.cli.create import _is_subtask_type
+
+        # Both common spellings normalize to "subtask"
+        assert _is_subtask_type("Subtask", None) is True
+        assert _is_subtask_type("Sub-task", None) is True
+        assert _is_subtask_type("sub task", None) is True
+        assert _is_subtask_type("Story", None) is False
+
+
+class TestCreateSubtask:
+    """Test sub-task creation via --parent (#85)."""
+
+    @patch("budjira.cli.create._load_project_metadata")
+    @patch("budjira.cli.create.JiraClient")
+    @patch("budjira.cli.create.get_active_connection")
+    def test_subtask_with_parent_passes_parent_field(
+        self,
+        mock_get_active_connection: Mock,
+        mock_jira_client_class: Mock,
+        mock_load_metadata: Mock,
+        mock_connection: Connection,
+        mock_created_issue: Issue,
+    ) -> None:
+        mock_get_active_connection.return_value = mock_connection
+        mock_load_metadata.return_value = None
+
+        mock_client = MagicMock()
+        mock_client.create_issue.return_value = mock_created_issue
+        mock_jira_client_class.from_connection.return_value = mock_client
+
+        result = runner.invoke(
+            app,
+            ["Work block", "--type", "Subtask", "--parent", "TEST-123", "--no-interactive"],
+        )
+
+        assert result.exit_code == 0
+        kwargs = mock_client.create_issue.call_args.kwargs
+        assert kwargs["parent"] == {"key": "TEST-123"}
+
+    @patch("budjira.cli.create._load_project_metadata")
+    @patch("budjira.cli.create.JiraClient")
+    @patch("budjira.cli.create.get_active_connection")
+    def test_subtask_without_parent_fails_fast(
+        self,
+        mock_get_active_connection: Mock,
+        mock_jira_client_class: Mock,
+        mock_load_metadata: Mock,
+        mock_connection: Connection,
+    ) -> None:
+        mock_get_active_connection.return_value = mock_connection
+        mock_load_metadata.return_value = None
+
+        mock_client = MagicMock()
+        mock_jira_client_class.from_connection.return_value = mock_client
+
+        result = runner.invoke(
+            app,
+            ["Work block", "--type", "Subtask", "--no-interactive"],
+        )
+
+        assert result.exit_code == 1
+        assert "requires a parent" in result.stdout
+        # Must fail before hitting the API
+        mock_client.create_issue.assert_not_called()
+
+    @patch("budjira.cli.create._load_project_metadata")
+    @patch("budjira.cli.create.JiraClient")
+    @patch("budjira.cli.create.get_active_connection")
+    def test_non_subtask_does_not_require_parent(
+        self,
+        mock_get_active_connection: Mock,
+        mock_jira_client_class: Mock,
+        mock_load_metadata: Mock,
+        mock_connection: Connection,
+        mock_created_issue: Issue,
+    ) -> None:
+        mock_get_active_connection.return_value = mock_connection
+        mock_load_metadata.return_value = None
+
+        mock_client = MagicMock()
+        mock_client.create_issue.return_value = mock_created_issue
+        mock_jira_client_class.from_connection.return_value = mock_client
+
+        result = runner.invoke(app, ["A story", "--type", "Story", "--no-interactive"])
+
+        assert result.exit_code == 0
+        # No parent field should be passed for a regular type
+        assert "parent" not in mock_client.create_issue.call_args.kwargs
+
+    @patch("budjira.cli.create.Prompt")
+    def test_interactive_prompts_for_parent_on_subtask(self, mock_prompt: Mock) -> None:
+        from budjira.cli.create import _get_parent_input
+
+        mock_prompt.ask.return_value = "TEST-999"
+        result = _get_parent_input(interactive=True, parent=None, issue_type="Subtask", metadata=None)
+        assert result == "TEST-999"
+        mock_prompt.ask.assert_called_once()
+
+    @patch("budjira.cli.create.Prompt")
+    def test_interactive_does_not_prompt_for_non_subtask(self, mock_prompt: Mock) -> None:
+        from budjira.cli.create import _get_parent_input
+
+        result = _get_parent_input(interactive=True, parent=None, issue_type="Story", metadata=None)
+        assert result is None
+        mock_prompt.ask.assert_not_called()
+
+    @patch("budjira.cli.create.Prompt")
+    def test_explicit_parent_skips_prompt(self, mock_prompt: Mock) -> None:
+        from budjira.cli.create import _get_parent_input
+
+        result = _get_parent_input(interactive=True, parent="TEST-1", issue_type="Subtask", metadata=None)
+        assert result == "TEST-1"
+        mock_prompt.ask.assert_not_called()

--- a/tests/cli/test_sprint.py
+++ b/tests/cli/test_sprint.py
@@ -1,5 +1,6 @@
 """Tests for sprint CLI commands."""
 
+import json
 from datetime import date
 from unittest.mock import MagicMock, Mock, patch
 
@@ -346,3 +347,261 @@ def test_sprint_show_status_and_type_filters(mock_get_conn: Mock, mock_jira_cls:
     jql = call_args[1].get("jql_filter") or ""
     assert 'status = "In Progress"' in jql
     assert 'issuetype = "Bug"' in jql
+
+
+def _mock_client_and_conn(mock_get_conn: Mock, mock_jira_cls: Mock, board_id: int | None = 42) -> MagicMock:
+    """Wire up a mock connection + client for write-op tests."""
+    mock_conn = MagicMock()
+    mock_conn.name = "test"
+    mock_conn.project_key = "TEST"
+    mock_conn.board_id = board_id
+    mock_get_conn.return_value = mock_conn
+
+    mock_client = MagicMock()
+    mock_jira_cls.from_connection.return_value = mock_client
+    return mock_client
+
+
+# Sprint move tests
+
+
+def test_sprint_move_help() -> None:
+    result = runner.invoke(app, ["sprint", "move", "--help"])
+    assert result.exit_code == 0
+
+
+@patch("budjira.cli.sprint.JiraClient")
+@patch("budjira.cli.sprint.get_active_connection")
+def test_sprint_move_by_name(mock_get_conn: Mock, mock_jira_cls: Mock) -> None:
+    mock_client = _mock_client_and_conn(mock_get_conn, mock_jira_cls)
+    mock_client.sprints.find_sprint_by_name.return_value = _make_sprint(100, "Sprint 10")
+
+    result = runner.invoke(app, ["-q", "sprint", "move", "TEST-1", "TEST-2", "--to", "Sprint 10"])
+    assert result.exit_code == 0
+    mock_client.sprints.find_sprint_by_name.assert_called_once_with(42, "Sprint 10")
+    mock_client.sprints.move_issues.assert_called_once_with(100, ["TEST-1", "TEST-2"])
+    assert "Moved 2 issue(s)" in result.stdout
+
+
+@patch("budjira.cli.sprint.JiraClient")
+@patch("budjira.cli.sprint.get_active_connection")
+def test_sprint_move_by_id(mock_get_conn: Mock, mock_jira_cls: Mock) -> None:
+    mock_client = _mock_client_and_conn(mock_get_conn, mock_jira_cls)
+    mock_client.sprints.get_sprint.return_value = _make_sprint(100, "Sprint 10")
+
+    result = runner.invoke(app, ["-q", "sprint", "move", "TEST-1", "--sprint-id", "100"])
+    assert result.exit_code == 0
+    mock_client.sprints.get_sprint.assert_called_once_with(100)
+    mock_client.sprints.move_issues.assert_called_once_with(100, ["TEST-1"])
+
+
+@patch("budjira.cli.sprint.JiraClient")
+@patch("budjira.cli.sprint.get_active_connection")
+def test_sprint_move_requires_target(mock_get_conn: Mock, mock_jira_cls: Mock) -> None:
+    _mock_client_and_conn(mock_get_conn, mock_jira_cls)
+
+    result = runner.invoke(app, ["-q", "sprint", "move", "TEST-1"])
+    assert result.exit_code == 1
+    assert "--to" in result.stdout or "--sprint-id" in result.stdout
+
+
+# Sprint create tests
+
+
+def test_sprint_create_help() -> None:
+    result = runner.invoke(app, ["sprint", "create", "--help"])
+    assert result.exit_code == 0
+
+
+@patch("budjira.cli.sprint.JiraClient")
+@patch("budjira.cli.sprint.get_active_connection")
+def test_sprint_create_basic(mock_get_conn: Mock, mock_jira_cls: Mock) -> None:
+    mock_client = _mock_client_and_conn(mock_get_conn, mock_jira_cls)
+    mock_client.sprints.create_sprint.return_value = _make_sprint(200, "Sprint 20", SprintState.FUTURE)
+
+    result = runner.invoke(app, ["-q", "sprint", "create", "Sprint 20"])
+    assert result.exit_code == 0
+    mock_client.sprints.create_sprint.assert_called_once()
+    kwargs = mock_client.sprints.create_sprint.call_args.kwargs
+    assert kwargs["name"] == "Sprint 20"
+    assert kwargs["board_id"] == 42
+    assert kwargs["start_date"] is None
+    assert "Created sprint 'Sprint 20'" in result.stdout
+
+
+@patch("budjira.cli.sprint.JiraClient")
+@patch("budjira.cli.sprint.get_active_connection")
+def test_sprint_create_with_future_dates(mock_get_conn: Mock, mock_jira_cls: Mock) -> None:
+    mock_client = _mock_client_and_conn(mock_get_conn, mock_jira_cls)
+    mock_client.sprints.create_sprint.return_value = _make_sprint(200, "Sprint 20", SprintState.FUTURE)
+
+    result = runner.invoke(app, ["-q", "sprint", "create", "Sprint 20", "--start", "today", "--end", "2099-12-31"])
+    assert result.exit_code == 0
+    kwargs = mock_client.sprints.create_sprint.call_args.kwargs
+    assert kwargs["start_date"] is not None
+    assert kwargs["end_date"] is not None
+    assert kwargs["end_date"].year == 2099
+
+
+# Sprint start tests
+
+
+def test_sprint_start_help() -> None:
+    result = runner.invoke(app, ["sprint", "start", "--help"])
+    assert result.exit_code == 0
+
+
+@patch("budjira.cli.sprint.JiraClient")
+@patch("budjira.cli.sprint.get_active_connection")
+def test_sprint_start_with_force(mock_get_conn: Mock, mock_jira_cls: Mock) -> None:
+    mock_client = _mock_client_and_conn(mock_get_conn, mock_jira_cls)
+    mock_client.sprints.find_sprint_by_name.return_value = _make_sprint(100, "Sprint 10", SprintState.FUTURE)
+    mock_client.sprints.start_sprint.return_value = _make_sprint(100, "Sprint 10", SprintState.ACTIVE)
+
+    result = runner.invoke(
+        app, ["-q", "sprint", "start", "Sprint 10", "--start", "today", "--end", "2099-12-31", "--force"]
+    )
+    assert result.exit_code == 0
+    mock_client.sprints.start_sprint.assert_called_once()
+    assert mock_client.sprints.start_sprint.call_args.args[0] == 100
+    assert "Started sprint 'Sprint 10'" in result.stdout
+
+
+@patch("budjira.cli.sprint.JiraClient")
+@patch("budjira.cli.sprint.get_active_connection")
+def test_sprint_start_requires_target(mock_get_conn: Mock, mock_jira_cls: Mock) -> None:
+    _mock_client_and_conn(mock_get_conn, mock_jira_cls)
+
+    result = runner.invoke(app, ["-q", "sprint", "start", "--force"])
+    assert result.exit_code == 1
+    assert "No sprint specified" in result.stdout
+
+
+@patch("budjira.cli.sprint.JiraClient")
+@patch("budjira.cli.sprint.get_active_connection")
+def test_sprint_start_abort_on_decline(mock_get_conn: Mock, mock_jira_cls: Mock) -> None:
+    mock_client = _mock_client_and_conn(mock_get_conn, mock_jira_cls)
+    mock_client.sprints.find_sprint_by_name.return_value = _make_sprint(100, "Sprint 10", SprintState.FUTURE)
+
+    result = runner.invoke(app, ["-q", "sprint", "start", "Sprint 10"], input="n\n")
+    assert result.exit_code == 0
+    mock_client.sprints.start_sprint.assert_not_called()
+    assert "Aborted" in result.stdout
+
+
+# Sprint close tests
+
+
+def test_sprint_close_help() -> None:
+    result = runner.invoke(app, ["sprint", "close", "--help"])
+    assert result.exit_code == 0
+
+
+@patch("budjira.cli.sprint.JiraClient")
+@patch("budjira.cli.sprint.get_active_connection")
+def test_sprint_close_active_with_force(mock_get_conn: Mock, mock_jira_cls: Mock) -> None:
+    mock_client = _mock_client_and_conn(mock_get_conn, mock_jira_cls)
+    mock_client.sprints.get_active_sprint.return_value = _make_sprint(100, "Sprint 10", SprintState.ACTIVE)
+    mock_client.sprints.close_sprint.return_value = _make_sprint(100, "Sprint 10", SprintState.CLOSED)
+
+    result = runner.invoke(app, ["-q", "sprint", "close", "--force"])
+    assert result.exit_code == 0
+    mock_client.sprints.close_sprint.assert_called_once_with(100)
+    assert "Closed sprint 'Sprint 10'" in result.stdout
+
+
+@patch("budjira.cli.sprint.JiraClient")
+@patch("budjira.cli.sprint.get_active_connection")
+def test_sprint_close_json_requires_force(mock_get_conn: Mock, mock_jira_cls: Mock) -> None:
+    mock_client = _mock_client_and_conn(mock_get_conn, mock_jira_cls)
+    mock_client.sprints.find_sprint_by_name.return_value = _make_sprint(100, "Sprint 10", SprintState.ACTIVE)
+
+    result = runner.invoke(app, ["-q", "--format", "json", "sprint", "close", "Sprint 10"])
+    assert result.exit_code == 1
+    assert "Confirmation required" in result.stdout
+    mock_client.sprints.close_sprint.assert_not_called()
+
+
+# JSON output contract tests (success paths)
+
+
+@patch("budjira.cli.sprint.JiraClient")
+@patch("budjira.cli.sprint.get_active_connection")
+def test_sprint_move_json_output(mock_get_conn: Mock, mock_jira_cls: Mock) -> None:
+    mock_client = _mock_client_and_conn(mock_get_conn, mock_jira_cls)
+    mock_client.sprints.find_sprint_by_name.return_value = _make_sprint(100, "Sprint 10")
+
+    result = runner.invoke(app, ["-q", "--format", "json", "sprint", "move", "TEST-1", "TEST-2", "--to", "Sprint 10"])
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["moved"] == ["TEST-1", "TEST-2"]
+    assert payload["sprint"]["id"] == 100
+    assert payload["sprint"]["name"] == "Sprint 10"
+
+
+@patch("budjira.cli.sprint.JiraClient")
+@patch("budjira.cli.sprint.get_active_connection")
+def test_sprint_create_json_output(mock_get_conn: Mock, mock_jira_cls: Mock) -> None:
+    mock_client = _mock_client_and_conn(mock_get_conn, mock_jira_cls)
+    mock_client.sprints.create_sprint.return_value = _make_sprint(200, "Sprint 20", SprintState.FUTURE)
+
+    result = runner.invoke(app, ["-q", "--format", "json", "sprint", "create", "Sprint 20"])
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["id"] == 200
+    assert payload["state"] == "future"
+
+
+@patch("budjira.cli.sprint.JiraClient")
+@patch("budjira.cli.sprint.get_active_connection")
+def test_sprint_start_json_output(mock_get_conn: Mock, mock_jira_cls: Mock) -> None:
+    mock_client = _mock_client_and_conn(mock_get_conn, mock_jira_cls)
+    mock_client.sprints.find_sprint_by_name.return_value = _make_sprint(100, "Sprint 10", SprintState.FUTURE)
+    mock_client.sprints.start_sprint.return_value = _make_sprint(100, "Sprint 10", SprintState.ACTIVE)
+
+    result = runner.invoke(
+        app,
+        ["-q", "--format", "json", "sprint", "start", "Sprint 10", "--start", "today", "--end", "2099-12-31", "-f"],
+    )
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["id"] == 100
+    assert payload["state"] == "active"
+
+
+@patch("budjira.cli.sprint.JiraClient")
+@patch("budjira.cli.sprint.get_active_connection")
+def test_sprint_close_json_output(mock_get_conn: Mock, mock_jira_cls: Mock) -> None:
+    mock_client = _mock_client_and_conn(mock_get_conn, mock_jira_cls)
+    mock_client.sprints.get_active_sprint.return_value = _make_sprint(100, "Sprint 10", SprintState.ACTIVE)
+    mock_client.sprints.close_sprint.return_value = _make_sprint(100, "Sprint 10", SprintState.CLOSED)
+
+    result = runner.invoke(app, ["-q", "--format", "json", "sprint", "close", "--force"])
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["id"] == 100
+    assert payload["state"] == "closed"
+
+
+@patch("budjira.cli.sprint.JiraClient")
+@patch("budjira.cli.sprint.get_active_connection")
+def test_sprint_start_json_requires_force(mock_get_conn: Mock, mock_jira_cls: Mock) -> None:
+    mock_client = _mock_client_and_conn(mock_get_conn, mock_jira_cls)
+    mock_client.sprints.find_sprint_by_name.return_value = _make_sprint(100, "Sprint 10", SprintState.FUTURE)
+
+    result = runner.invoke(app, ["-q", "--format", "json", "sprint", "start", "Sprint 10"])
+    assert result.exit_code == 1
+    assert "Confirmation required" in result.stdout
+    mock_client.sprints.start_sprint.assert_not_called()
+
+
+@patch("budjira.cli.sprint.JiraClient")
+@patch("budjira.cli.sprint.get_active_connection")
+def test_sprint_close_abort_on_decline(mock_get_conn: Mock, mock_jira_cls: Mock) -> None:
+    mock_client = _mock_client_and_conn(mock_get_conn, mock_jira_cls)
+    mock_client.sprints.get_active_sprint.return_value = _make_sprint(100, "Sprint 10", SprintState.ACTIVE)
+
+    result = runner.invoke(app, ["-q", "sprint", "close"], input="n\n")
+    assert result.exit_code == 0
+    mock_client.sprints.close_sprint.assert_not_called()
+    assert "Aborted" in result.stdout

--- a/tests/services/test_sprints.py
+++ b/tests/services/test_sprints.py
@@ -1,5 +1,6 @@
 """Tests for SprintService."""
 
+from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -240,3 +241,97 @@ class TestFindSprintByName:
 
         with pytest.raises(JiraAPIError, match="Multiple sprints match"):
             service.find_sprint_by_name(42, "Sprint 1")
+
+
+class TestGetSprint:
+    """Tests for SprintService.get_sprint."""
+
+    def test_returns_sprint(self, service: SprintService, mock_jira_client: MagicMock) -> None:
+        mock_jira_client.sprint.return_value = _make_jira_sprint(100, "Sprint 10", "active")
+
+        sprint = service.get_sprint(100)
+        assert sprint.id == 100
+        assert sprint.name == "Sprint 10"
+        mock_jira_client.sprint.assert_called_once_with(100)
+
+    def test_not_found(self, service: SprintService, mock_jira_client: MagicMock) -> None:
+        from budjira.utils.errors import InvalidIssueError
+
+        mock_jira_client.sprint.side_effect = JIRAError(status_code=404, text="Not found")
+        with pytest.raises(InvalidIssueError, match="not found"):
+            service.get_sprint(999)
+
+
+class TestMoveIssues:
+    """Tests for SprintService.move_issues."""
+
+    def test_moves_issues(self, service: SprintService, mock_jira_client: MagicMock) -> None:
+        service.move_issues(100, ["TEST-1", "TEST-2"])
+        mock_jira_client.add_issues_to_sprint.assert_called_once_with(sprint_id=100, issue_keys=["TEST-1", "TEST-2"])
+
+    def test_permission_error(self, service: SprintService, mock_jira_client: MagicMock) -> None:
+        mock_jira_client.add_issues_to_sprint.side_effect = JIRAError(status_code=403, text="Forbidden")
+        with pytest.raises(PermissionError):
+            service.move_issues(100, ["TEST-1"])
+
+
+class TestCreateSprint:
+    """Tests for SprintService.create_sprint."""
+
+    def test_creates_sprint(self, service: SprintService, mock_jira_client: MagicMock) -> None:
+        mock_jira_client.create_sprint.return_value = _make_jira_sprint(200, "Sprint 20", "future")
+
+        sprint = service.create_sprint(42, "Sprint 20")
+        assert sprint.id == 200
+        assert sprint.name == "Sprint 20"
+        mock_jira_client.create_sprint.assert_called_once_with(
+            name="Sprint 20", board_id=42, startDate=None, endDate=None, goal=None
+        )
+
+    def test_creates_sprint_with_dates_and_goal(self, service: SprintService, mock_jira_client: MagicMock) -> None:
+        mock_jira_client.create_sprint.return_value = _make_jira_sprint(200, "Sprint 20", "future")
+
+        start = datetime(2026, 6, 1, 0, 0, 0)
+        end = datetime(2026, 6, 14, 0, 0, 0)
+        service.create_sprint(42, "Sprint 20", start_date=start, end_date=end, goal="Ship it")
+
+        mock_jira_client.create_sprint.assert_called_once_with(
+            name="Sprint 20",
+            board_id=42,
+            startDate=start.isoformat(),
+            endDate=end.isoformat(),
+            goal="Ship it",
+        )
+
+    def test_permission_error(self, service: SprintService, mock_jira_client: MagicMock) -> None:
+        mock_jira_client.create_sprint.side_effect = JIRAError(status_code=403, text="Forbidden")
+        with pytest.raises(PermissionError):
+            service.create_sprint(42, "Sprint 20")
+
+
+class TestSprintStateTransitions:
+    """Tests for SprintService.start_sprint and close_sprint."""
+
+    def test_start_sprint(self, service: SprintService, mock_jira_client: MagicMock) -> None:
+        mock_jira_client.sprint.return_value = _make_jira_sprint(100, "Sprint 10", "active")
+        start = datetime(2026, 6, 1, 0, 0, 0)
+        end = datetime(2026, 6, 14, 0, 0, 0)
+
+        sprint = service.start_sprint(100, start_date=start, end_date=end)
+        assert sprint.state.value == "active"
+        mock_jira_client.update_sprint.assert_called_once_with(
+            id=100, state="active", startDate=start.isoformat(), endDate=end.isoformat()
+        )
+        mock_jira_client.sprint.assert_called_once_with(100)
+
+    def test_close_sprint(self, service: SprintService, mock_jira_client: MagicMock) -> None:
+        mock_jira_client.sprint.return_value = _make_jira_sprint(100, "Sprint 10", "closed")
+
+        sprint = service.close_sprint(100)
+        assert sprint.state.value == "closed"
+        mock_jira_client.update_sprint.assert_called_once_with(id=100, state="closed", startDate=None, endDate=None)
+
+    def test_start_sprint_error(self, service: SprintService, mock_jira_client: MagicMock) -> None:
+        mock_jira_client.update_sprint.side_effect = JIRAError(status_code=400, text="No dates set")
+        with pytest.raises(JiraAPIError):
+            service.start_sprint(100)

--- a/tests/utils/test_datetime_parser.py
+++ b/tests/utils/test_datetime_parser.py
@@ -137,3 +137,21 @@ class TestParseDatetimeString:
         past_str = past.strftime("%Y-%m-%d %H:%M:%S")
         result = parse_datetime_string(past_str)
         assert result <= datetime.now()
+
+    def test_future_allowed_when_flag_set(self) -> None:
+        """Future dates are accepted when allow_future=True (e.g. sprint dates)."""
+        future = datetime.now() + timedelta(days=30)
+        future_str = future.strftime("%Y-%m-%d")
+        result = parse_datetime_string(future_str, allow_future=True)
+        assert result.date() == future.date()
+
+    def test_parse_relative_tomorrow(self) -> None:
+        """'tomorrow' resolves to the next day at midnight when future is allowed."""
+        result = parse_datetime_string("tomorrow", allow_future=True)
+        expected = (datetime.now() + timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
+        assert result == expected
+
+    def test_tomorrow_rejected_without_future_flag(self) -> None:
+        """'tomorrow' is rejected when future dates are not allowed."""
+        with pytest.raises(ValidationError, match="cannot be in the future"):
+            parse_datetime_string("tomorrow")


### PR DESCRIPTION
## Summary

Two feature additions that unblock the Epic > Story > Sub-task planning and booking workflow, plus a type-safety cleanup.

### feat(sprint): move/create/start/close (#78)
Completes the sprint surface beyond read-only `list`/`show`:
- `sprint move ISSUE… --to NAME | --sprint-id ID` — assign issues to a sprint (additive, no prompt)
- `sprint create NAME [--start --end --goal]` — create a future sprint
- `sprint start [NAME] / close [NAME]` — drive the lifecycle (confirmation, `--force`; `close` defaults to the active sprint)

`SprintService` gains `get_sprint`, `move_issues`, `create_sprint`, `start_sprint`, `close_sprint`. `parse_datetime_string` grows an `allow_future` flag (+ `tomorrow`) so sprint dates may lie in the future **without** affecting the past-only worklog/tempo/workflow callers. All commands support `--board`, `--connection`, `--format json`; state changes require `--force` in JSON mode.

> Deviation from #78: the issue proposed a trailing positional sprint name, which is ambiguous with variadic issue keys. Implemented as `--to` / `--sprint-id` instead.

### feat(create): sub-task creation via --parent (#85)
`create issue --type Subtask --parent PROJ-123` now sets `fields.parent`. Sub-task types are detected via the authoritative `subtask` flag from cached project metadata (robust to `Subtask` vs `Sub-task` naming), with a name heuristic fallback. Creating a sub-task without a parent fails fast with an actionable error instead of the cryptic Jira response; interactive mode prompts for the parent.

### fix(types): mypy strict cleanup
Resolves two pre-existing `mypy --strict` errors (`Issue.delete` untyped call → `cast(Any, …)`; DoR prompt `template and …` → `template is not None and …`). The fixes work in both the local (jira installed) and CI (jira-less) mypy environments.

## Validation
- 847 passed, 3 skipped · coverage 86.00%
- `mypy --strict` clean across the full package (60 files)
- ruff, ruff-format, bandit all green

Closes #78
Closes #85