### PR TITLE
fix(sprint): support team-managed boards + --sprint-id skips detection (#87)

### DIFF
--- a/.claude/context.md
+++ b/.claude/context.md
@@ -317,7 +317,8 @@ budjira/tempo/client.py        90%
 - **#73** - Auto-discover Jira project metadata → Released v1.19.0
 
 ### In Progress / Open
-- **#85** - Sub-task creation via `--parent` → implementiert, Release ausstehend (blockierte Epic>Story>Sub-task-Buchung)
+- **#87** - Sprint support for team-managed projects (board type `simple`) + `--sprint-id` skips board detection → fix, Release 1.21.1 ausstehend
+- **#85** - Sub-task creation via `--parent` → released v1.21.0 (blockierte Epic>Story>Sub-task-Buchung)
 - **#78** - Sprint move + lifecycle (move/create/start/close) → implementiert, Release ausstehend
 - **#74** - Local-first release workflow → erledigt (v1.20.0, cz bump)
 - **#75** - AI prompt optimization (nicht gestartet)

--- a/README.md
+++ b/README.md
@@ -376,6 +376,9 @@ budjira --format json epic show PROJ-100
 
 Query sprints, move issues between them, and drive the sprint lifecycle from
 the CLI. The board is auto-detected (or set `board_id` in `connections.toml`).
+Both company-managed (Scrum) and team-managed boards are supported; for
+team-managed projects you can also pass `--sprint-id` directly, which skips
+board detection entirely.
 
 ```bash
 # List sprints (optionally filter by state)

--- a/budjira/cli/sprint.py
+++ b/budjira/cli/sprint.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Annotated
+from typing import TYPE_CHECKING, Annotated
 
 import typer
 from rich.console import Console
@@ -14,6 +14,9 @@ from budjira.utils.connection import get_active_connection
 from budjira.utils.datetime_parser import parse_datetime_string
 from budjira.utils.errors import BudjiraError
 from budjira.utils.formatter import OutputFormatter
+
+if TYPE_CHECKING:
+    from budjira.models.connection import Connection
 
 app = typer.Typer(
     name="sprint",
@@ -80,17 +83,24 @@ def _resolve_sprint(
 
 def _resolve_target(
     client: JiraClient,
-    board_id: int,
+    conn: Connection,
+    board: int | None,
     sprint_name: str | None,
     sprint_id: int | None,
     allow_active: bool,
 ) -> Sprint:
     """Resolve a target sprint by ID, name, or (optionally) the active sprint.
 
+    Board detection is performed lazily: when an explicit ``sprint_id`` is given
+    the sprint is fetched directly via the agile API and no board is resolved at
+    all. This is what makes ``--sprint-id`` work for team-managed projects whose
+    board type is not auto-detected.
+
     Args:
         client: Jira client
-        board_id: Board ID (used for name lookup / active sprint)
-        sprint_id: Explicit sprint ID (highest priority)
+        conn: Active connection (provides board_id default and project key)
+        board: Explicit --board flag value (overrides detection)
+        sprint_id: Explicit sprint ID (highest priority; skips board resolution)
         sprint_name: Sprint name (case-insensitive partial match)
         allow_active: If True and neither id nor name given, fall back to the
             active sprint; otherwise require an explicit target
@@ -101,8 +111,11 @@ def _resolve_target(
     Raises:
         BudjiraError: If no target can be resolved
     """
+    # --sprint-id needs no board: fetch directly via the agile sprint endpoint.
     if sprint_id is not None:
         return client.sprints.get_sprint(sprint_id)
+
+    board_id = _resolve_board_id(client, board, conn.board_id, conn.project_key)
     if sprint_name:
         return client.sprints.find_sprint_by_name(board_id, sprint_name)
     if allow_active:
@@ -414,8 +427,7 @@ def sprint_move(
             console.print(f"[dim]Using connection: {conn.name}[/dim]\n")
 
         client = JiraClient.from_connection(conn)
-        board_id = _resolve_board_id(client, board, conn.board_id, conn.project_key)
-        sprint = _resolve_target(client, board_id, to, sprint_id, allow_active=False)
+        sprint = _resolve_target(client, conn, board, to, sprint_id, allow_active=False)
 
         client.sprints.move_issues(sprint.id, issue_keys)
 
@@ -552,8 +564,7 @@ def sprint_start(
             console.print(f"[dim]Using connection: {conn.name}[/dim]\n")
 
         client = JiraClient.from_connection(conn)
-        board_id = _resolve_board_id(client, board, conn.board_id, conn.project_key)
-        sprint = _resolve_target(client, board_id, sprint_name, sprint_id, allow_active=False)
+        sprint = _resolve_target(client, conn, board, sprint_name, sprint_id, allow_active=False)
 
         if not force:
             if is_json:
@@ -620,8 +631,7 @@ def sprint_close(
             console.print(f"[dim]Using connection: {conn.name}[/dim]\n")
 
         client = JiraClient.from_connection(conn)
-        board_id = _resolve_board_id(client, board, conn.board_id, conn.project_key)
-        sprint = _resolve_target(client, board_id, sprint_name, sprint_id, allow_active=True)
+        sprint = _resolve_target(client, conn, board, sprint_name, sprint_id, allow_active=True)
 
         if not force:
             if is_json:

--- a/budjira/models/ai_prompt.py
+++ b/budjira/models/ai_prompt.py
@@ -1381,7 +1381,12 @@ budjira sprint close "Sprint 42" --force
 The board is resolved in this order:
 1. `--board` CLI flag (highest priority)
 2. `board_id` from connection config (set in connections.toml)
-3. Auto-detection from project (works when exactly one Scrum board exists)
+3. Auto-detection from project (works when exactly one sprint-capable board exists)
+
+Both company-managed (board type `scrum`) and team-managed (board type `simple`)
+projects are supported. For team-managed projects, passing `--sprint-id`
+directly to `sprint move/start/close` skips board detection entirely and
+operates on the sprint via the agile API.
 
 To configure a default board in `connections.toml`:
 ```toml

--- a/budjira/services/sprints.py
+++ b/budjira/services/sprints.py
@@ -17,10 +17,17 @@ if TYPE_CHECKING:
 
 
 class SprintService(BaseJiraService):
-    """Service for querying Jira sprints and scrum boards."""
+    """Service for querying Jira sprints and boards."""
+
+    # Board types that support sprints: 'scrum' (company-managed) and
+    # 'simple' (team-managed / next-gen). 'kanban' boards have no sprints.
+    SPRINT_BOARD_TYPES = ("scrum", "simple")
 
     def get_boards(self, project_key: str) -> list[Board]:
-        """Get scrum boards for a project.
+        """Get all boards for a project.
+
+        Returns boards of every type (scrum, simple, kanban). Filtering to
+        sprint-capable boards is done by the caller (see ``detect_board``).
 
         Args:
             project_key: Jira project key (e.g., PROJ)
@@ -33,9 +40,11 @@ class SprintService(BaseJiraService):
         """
         try:
             self._log_operation("Get boards", project_key=project_key)
-            jira_boards = self._client.boards(projectKeyOrID=project_key, type="scrum")
+            # No server-side type filter: team-managed boards report type
+            # 'simple' and would be hidden by type='scrum'.
+            jira_boards = self._client.boards(projectKeyOrID=project_key)
             boards = [Board.from_jira_board(b) for b in jira_boards]
-            self._logger.info(f"Found {len(boards)} scrum boards for project {project_key}")
+            self._logger.info(f"Found {len(boards)} boards for project {project_key}")
             return boards
         except JIRAError as e:
             self._handle_jira_error(e, "Get boards", project_key=project_key)
@@ -44,9 +53,10 @@ class SprintService(BaseJiraService):
             raise JiraAPIError(f"Failed to get boards for project {project_key}: {e}") from e
 
     def detect_board(self, project_key: str) -> Board:
-        """Auto-detect the scrum board for a project.
+        """Auto-detect the sprint-capable board for a project.
 
-        Works when there is exactly one scrum board. Raises an error otherwise
+        Accepts both company-managed (``scrum``) and team-managed (``simple``)
+        boards. Works when there is exactly one such board; raises otherwise
         with guidance to use --board.
 
         Args:
@@ -56,19 +66,21 @@ class SprintService(BaseJiraService):
             Detected Board object
 
         Raises:
-            JiraAPIError: If no boards or multiple boards found
+            JiraAPIError: If no sprint-capable board or multiple are found
         """
-        boards = self.get_boards(project_key)
+        boards = [b for b in self.get_boards(project_key) if b.board_type in self.SPRINT_BOARD_TYPES]
 
         if len(boards) == 0:
             raise JiraAPIError(
-                f"No scrum boards found for project '{project_key}'. Ensure the project uses a Scrum board in Jira."
+                f"No sprint-capable board found for project '{project_key}'. Ensure the project has a "
+                f"Scrum (company-managed) or team-managed board with sprints enabled. "
+                f"For team-managed projects you can also pass --sprint-id directly."
             )
 
         if len(boards) > 1:
             board_list = ", ".join(f"{b.name} (ID: {b.id})" for b in boards)
             raise JiraAPIError(
-                f"Multiple scrum boards found for project '{project_key}': {board_list}. "
+                f"Multiple sprint-capable boards found for project '{project_key}': {board_list}. "
                 f"Use --board to specify which board to use."
             )
 

--- a/tests/cli/test_sprint.py
+++ b/tests/cli/test_sprint.py
@@ -397,6 +397,20 @@ def test_sprint_move_by_id(mock_get_conn: Mock, mock_jira_cls: Mock) -> None:
 
 @patch("budjira.cli.sprint.JiraClient")
 @patch("budjira.cli.sprint.get_active_connection")
+def test_sprint_move_by_id_skips_board_detection(mock_get_conn: Mock, mock_jira_cls: Mock) -> None:
+    """--sprint-id must not trigger board auto-detection (team-managed safe, #87)."""
+    mock_client = _mock_client_and_conn(mock_get_conn, mock_jira_cls, board_id=None)
+    mock_client.sprints.get_sprint.return_value = _make_sprint(107, "Future Sprint", SprintState.FUTURE)
+
+    result = runner.invoke(app, ["-q", "sprint", "move", "PROJ-1", "PROJ-2", "--sprint-id", "107"])
+    assert result.exit_code == 0
+    mock_client.sprints.move_issues.assert_called_once_with(107, ["PROJ-1", "PROJ-2"])
+    # The whole point of #87: no board lookup at all when --sprint-id is given.
+    mock_client.sprints.detect_board.assert_not_called()
+
+
+@patch("budjira.cli.sprint.JiraClient")
+@patch("budjira.cli.sprint.get_active_connection")
 def test_sprint_move_requires_target(mock_get_conn: Mock, mock_jira_cls: Mock) -> None:
     _mock_client_and_conn(mock_get_conn, mock_jira_cls)
 

--- a/tests/services/test_sprints.py
+++ b/tests/services/test_sprints.py
@@ -74,7 +74,8 @@ class TestGetBoards:
         assert len(boards) == 2
         assert boards[0].id == 1
         assert boards[1].id == 2
-        mock_jira_client.boards.assert_called_once_with(projectKeyOrID="TEST", type="scrum")
+        # No server-side type filter so team-managed ('simple') boards are visible too.
+        mock_jira_client.boards.assert_called_once_with(projectKeyOrID="TEST")
 
     def test_empty_boards(self, service: SprintService, mock_jira_client: MagicMock) -> None:
         mock_jira_client.boards.return_value = []
@@ -97,9 +98,22 @@ class TestDetectBoard:
         assert board.id == 42
         assert board.name == "My Board"
 
+    def test_team_managed_simple_board(self, service: SprintService, mock_jira_client: MagicMock) -> None:
+        # Team-managed projects expose a board of type 'simple' (not 'scrum').
+        mock_jira_client.boards.return_value = [_make_jira_board(99, "TM Board", board_type="simple")]
+
+        board = service.detect_board("TEST")
+        assert board.id == 99
+        assert board.board_type == "simple"
+
     def test_no_boards(self, service: SprintService, mock_jira_client: MagicMock) -> None:
         mock_jira_client.boards.return_value = []
-        with pytest.raises(JiraAPIError, match="No scrum boards found"):
+        with pytest.raises(JiraAPIError, match="No sprint-capable board"):
+            service.detect_board("TEST")
+
+    def test_kanban_only_is_not_sprint_capable(self, service: SprintService, mock_jira_client: MagicMock) -> None:
+        mock_jira_client.boards.return_value = [_make_jira_board(7, "Kanban", board_type="kanban")]
+        with pytest.raises(JiraAPIError, match="No sprint-capable board"):
             service.detect_board("TEST")
 
     def test_multiple_boards(self, service: SprintService, mock_jira_client: MagicMock) -> None:
@@ -107,8 +121,17 @@ class TestDetectBoard:
             _make_jira_board(1, "Board A"),
             _make_jira_board(2, "Board B"),
         ]
-        with pytest.raises(JiraAPIError, match="Multiple scrum boards"):
+        with pytest.raises(JiraAPIError, match="Multiple sprint-capable boards"):
             service.detect_board("TEST")
+
+    def test_kanban_ignored_when_one_sprint_board(self, service: SprintService, mock_jira_client: MagicMock) -> None:
+        # A kanban board alongside one scrum board must not trigger the "multiple" error.
+        mock_jira_client.boards.return_value = [
+            _make_jira_board(1, "Kanban", board_type="kanban"),
+            _make_jira_board(2, "Scrum", board_type="scrum"),
+        ]
+        board = service.detect_board("TEST")
+        assert board.id == 2
 
 
 class TestGetSprints:


### PR DESCRIPTION
## Problem (#87)
Sprint commands failed for **team-managed** Jira Cloud projects. Board detection hard-filtered board type `scrum`, so team-managed boards (type `simple`) were rejected with `No scrum boards found` — even when a valid `--sprint-id` was passed (the agile endpoint `POST /sprint/{id}/issue` works fine for those sprints).

## Fix
- **`detect_board`**: accepts sprint-capable boards (`scrum` + `simple`), drops the server-side `type=scrum` filter, excludes `kanban`. Multiple sprint-capable boards still error with `--board` guidance (unchanged behavior).
- **`sprint move/start/close`**: board resolution is now lazy — with `--sprint-id` the sprint is fetched directly via the agile API and **board detection is skipped entirely**.

## Tests
- Service: team-managed (`simple`) board detected; kanban-only rejected; kanban ignored when one scrum board present; "multiple sprint-capable" error.
- CLI: `sprint move --sprint-id` asserts `detect_board` is **not** called.
- 851 passed, 86% coverage; mypy --strict clean; all pre-commit hooks green.

## Note
The `detect_board` gate is shared with the existing `sprint list`/`show` (v1.18.0), so this also fixes those for team-managed projects.

Closes #87