### PR TITLE
fix(issue): guard partial-field fetch in Issue parsing (#89)

### DIFF
--- a/.claude/context.md
+++ b/.claude/context.md
@@ -317,7 +317,8 @@ budjira/tempo/client.py        90%
 - **#73** - Auto-discover Jira project metadata → Released v1.19.0
 
 ### In Progress / Open
-- **#87** - Sprint support for team-managed projects (board type `simple`) + `--sprint-id` skips board detection → fix, Release 1.21.1 ausstehend
+- **#89** - `issue delete` crash beim Pre-Delete-Fetch (`PropertyHolder has no attribute`) → fix: `_parse_basic_fields` null-safe für partielle Fetches (`fields=["summary"]`), Release 1.21.2 ausstehend
+- **#87** - Sprint support for team-managed projects (board type `simple`) + `--sprint-id` skips board detection → released v1.21.1
 - **#85** - Sub-task creation via `--parent` → released v1.21.0 (blockierte Epic>Story>Sub-task-Buchung)
 - **#78** - Sprint move + lifecycle (move/create/start/close) → implementiert, Release ausstehend
 - **#74** - Local-first release workflow → erledigt (v1.20.0, cz bump)

--- a/budjira/models/issue.py
+++ b/budjira/models/issue.py
@@ -143,13 +143,16 @@ class Issue(BaseModel):
             Dictionary with basic field values
         """
         issue_id = int(jira_issue.id) if hasattr(jira_issue, "id") and jira_issue.id is not None else None
+        # Guard every field access: a partial fetch (e.g. fields=["summary"]) returns a
+        # PropertyHolder that only carries the requested fields, so issuetype/status may be
+        # absent. Unguarded access raised "'PropertyHolder' object has no attribute ...".
         return {
             "id": issue_id,
             "key": jira_issue.key,
-            "summary": fields.summary,
+            "summary": getattr(fields, "summary", "") or "",
             "description": fields.description if hasattr(fields, "description") else None,
-            "issue_type": fields.issuetype.name,
-            "status": fields.status.name,
+            "issue_type": fields.issuetype.name if getattr(fields, "issuetype", None) else "",
+            "status": fields.status.name if getattr(fields, "status", None) else "",
             "project_key": jira_issue.key.split("-")[0],
         }
 

--- a/tests/models/test_issue.py
+++ b/tests/models/test_issue.py
@@ -272,6 +272,28 @@ class TestIssue:
         assert issue.created is None
         assert issue.updated is None
 
+    def test_from_jira_issue_partial_fields_summary_only(self) -> None:
+        """A partial fetch (fields=["summary"]) must not crash on absent fields (#89).
+
+        Regression: `issue delete` fetched fields=["summary"], yielding a PropertyHolder
+        without issuetype/status. Unguarded access raised
+        "'PropertyHolder' object has no attribute 'issuetype'".
+        """
+        import types
+
+        # SimpleNamespace raises AttributeError on missing attrs, like jira's PropertyHolder.
+        fields = types.SimpleNamespace(summary="Only the title")
+        jira_issue = types.SimpleNamespace(id="123", key="PROJ-7", fields=fields)
+
+        issue = Issue.from_jira_issue(jira_issue)
+
+        assert issue.key == "PROJ-7"
+        assert issue.summary == "Only the title"
+        assert issue.issue_type == ""
+        assert issue.status == ""
+        assert issue.priority is None
+        assert issue.assignee is None
+
     def test_parse_issue_links_outward(self) -> None:
         """Test parsing issue links with outward direction."""
         # Mock Jira API response for outward link


### PR DESCRIPTION
## Problem (#89)
`budjira issue delete PROJ-123` aborted for **any** issue with:
```
Error: Unexpected error fetching issue: 'PropertyHolder' object has no attribute
```

## Root cause
`issue delete` fetches `client.issues.get(issue_key, fields=["summary"])` for the confirmation prompt. A restricted fetch returns a jira `PropertyHolder` carrying only `summary`. `Issue._parse_basic_fields` accessed `fields.issuetype.name` and `fields.status.name` **unguarded** (the only parser without `hasattr` guards) → `AttributeError`. Not team-managed-specific — it broke every `get(fields=[...])` partial fetch.

## Fix
Guard `summary`/`issuetype`/`status` in `_parse_basic_fields`, defaulting to empty strings when absent (consistent with the other parsers). Any partial fetch now parses safely.

## Tests
- New regression test: `from_jira_issue` with a `SimpleNamespace` fields object (only `summary`, raises `AttributeError` on missing attrs like `PropertyHolder`) → no crash, `issue_type`/`status` default to `""`.
- 852 passed, 86% coverage, mypy --strict clean, all pre-commit hooks green.

Closes #89