### PR TITLE
fix(logging): redact credentials from all log records

### DIFF
--- a/budjira/cli/main.py
+++ b/budjira/cli/main.py
@@ -24,6 +24,10 @@ from budjira.cli import (
     worklog,
 )
 from budjira.utils.banner import print_header
+from budjira.utils.redact import install_redaction
+
+# Credentials must never reach log output; scrub every record at creation.
+install_redaction()
 
 # Show header early for --help (which bypasses callback)
 # Check for --help and show header unless -q is present

--- a/budjira/utils/redact.py
+++ b/budjira/utils/redact.py
@@ -1,0 +1,72 @@
+"""Credential redaction for log output.
+
+budjira never logs credentials on purpose, but a future debug statement or an
+exception path that echoes request/session state must not leak live tokens
+into terminal output. This module makes that property structural instead of
+accidental: once installed, every ``logging.LogRecord`` is scrubbed at
+creation time, so the guarantee holds for all loggers and all handlers —
+including handlers added later that know nothing about redaction.
+
+Install happens once at CLI startup via :func:`install_redaction`.
+"""
+
+import logging
+import re
+import threading
+
+REDACTED = "***REDACTED***"
+
+# Token-ish value: long enough to be a credential, no whitespace.
+_VALUE = r"[A-Za-z0-9\-._~+/=]{8,}"
+
+_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    # HTTP auth schemes: "Bearer <token>" / "token <token>" (GitHub style)
+    (re.compile(rf"(?i)\b(bearer|token)\s+{_VALUE}"), rf"\1 {REDACTED}"),
+    # Header/dict style: Authorization: <anything up to quote/brace/newline>
+    (
+        re.compile(r"(?i)(authorization[\"']?\s*[:=]\s*[\"']?)[^\"'\r\n}]+"),
+        rf"\1{REDACTED}",
+    ),
+    # GitHub personal access tokens (classic and fine-grained)
+    (re.compile(r"\bgh[pousr]_[A-Za-z0-9]{20,}\b"), REDACTED),
+    (re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}\b"), REDACTED),
+    # Atlassian Cloud API tokens
+    (re.compile(rf"\bATATT{_VALUE}\b"), REDACTED),
+]
+
+_install_lock = threading.Lock()
+_installed = False
+
+
+def redact(text: str) -> str:
+    """Return ``text`` with credential-looking values masked."""
+    for pattern, replacement in _PATTERNS:
+        text = pattern.sub(replacement, text)
+    return text
+
+
+def install_redaction() -> None:
+    """Install credential redaction into the logging record factory.
+
+    Idempotent and thread-safe. The factory sees every record before any
+    handler does, so the redaction applies regardless of logging
+    configuration.
+    """
+    global _installed
+    with _install_lock:
+        if _installed:
+            return
+
+        previous_factory = logging.getLogRecordFactory()
+
+        def redacting_factory(*args: object, **kwargs: object) -> logging.LogRecord:
+            record = previous_factory(*args, **kwargs)
+            message = record.getMessage()
+            redacted = redact(message)
+            if redacted != message:
+                record.msg = redacted
+                record.args = ()
+            return record
+
+        logging.setLogRecordFactory(redacting_factory)
+        _installed = True

--- a/tests/utils/test_redact.py
+++ b/tests/utils/test_redact.py
@@ -1,0 +1,78 @@
+"""Tests for credential redaction in log output."""
+
+import logging
+
+import pytest
+from budjira.utils.redact import REDACTED, install_redaction, redact
+
+
+class TestRedact:
+    """Unit tests for the redact() text scrubber."""
+
+    def test_bearer_scheme_is_masked(self) -> None:
+        assert redact("Authorization: Bearer abcdef123456") == f"Authorization: {REDACTED}"
+
+    def test_bearer_value_is_masked_without_header_context(self) -> None:
+        assert redact("sending Bearer abcdef123456 now") == f"sending Bearer {REDACTED} now"
+
+    def test_github_token_scheme_is_masked(self) -> None:
+        assert redact("token ghp_abcdefghijklmnopqrstuvwxyz123456") == f"token {REDACTED}"
+
+    def test_github_pat_is_masked_anywhere(self) -> None:
+        assert redact("using ghp_abcdefghijklmnopqrstuvwxyz123456 for auth") == f"using {REDACTED} for auth"
+
+    def test_github_fine_grained_pat_is_masked(self) -> None:
+        token = "github_pat_11ABCDEFG0123456789_abcdefghijklmnopqrstuvwxyz"
+        assert redact(f"header {token}") == f"header {REDACTED}"
+
+    def test_atlassian_api_token_is_masked(self) -> None:
+        assert redact("ATATT3xFfGF0abcdefghijklmnop=AB12") == REDACTED
+
+    def test_authorization_dict_repr_is_masked(self) -> None:
+        text = "{'Authorization': 'Bearer abcdef123456', 'Content-Type': 'application/json'}"
+        assert "abcdef123456" not in redact(text)
+        assert "Content-Type" in redact(text)
+
+    def test_plain_text_is_untouched(self) -> None:
+        text = "the token count is high and the bearer of news arrived"
+        assert redact(text) == text
+
+    def test_redact_is_idempotent(self) -> None:
+        once = redact("Bearer abcdef123456")
+        assert redact(once) == once
+
+
+class TestInstallRedaction:
+    """Integration tests: redaction applies to emitted log records."""
+
+    @pytest.fixture(autouse=True)
+    def _install(self) -> None:
+        install_redaction()
+
+    def test_fstring_message_is_redacted(self, caplog: pytest.LogCaptureFixture) -> None:
+        logger = logging.getLogger("test.redact.fstring")
+        with caplog.at_level(logging.INFO):
+            logger.info(f"auth header: Bearer {'abcdef123456'}")
+        assert "abcdef123456" not in caplog.text
+        assert REDACTED in caplog.text
+
+    def test_percent_style_args_are_redacted(self, caplog: pytest.LogCaptureFixture) -> None:
+        logger = logging.getLogger("test.redact.args")
+        with caplog.at_level(logging.INFO):
+            logger.info("auth header: %s", "Bearer abcdef123456")
+        assert "abcdef123456" not in caplog.text
+        assert REDACTED in caplog.text
+
+    def test_clean_records_keep_their_args(self, caplog: pytest.LogCaptureFixture) -> None:
+        logger = logging.getLogger("test.redact.clean")
+        with caplog.at_level(logging.INFO):
+            logger.info("fetched %d issues", 42)
+        assert "fetched 42 issues" in caplog.text
+
+    def test_install_is_idempotent(self, caplog: pytest.LogCaptureFixture) -> None:
+        install_redaction()
+        install_redaction()
+        logger = logging.getLogger("test.redact.idempotent")
+        with caplog.at_level(logging.INFO):
+            logger.info("token ghp_abcdefghijklmnopqrstuvwxyz123456")
+        assert caplog.text.count(REDACTED) == 1


### PR DESCRIPTION
## Summary

Credentials must never reach log output. This PR installs a redacting LogRecord factory at CLI startup so Authorization headers, Bearer/token scheme values, GitHub PATs (`ghp_*`/`github_pat_*`) and Atlassian API tokens (`ATATT*`) are masked in every log record — for all loggers and all handlers, including handlers added in the future (no central logging setup exists today, so the factory is the only choke point that covers every path).

Closes #93.

## Changes

- new `budjira/utils/redact.py`: pattern-based `redact()` + idempotent, thread-safe `install_redaction()` via `logging.setLogRecordFactory`
- `budjira/cli/main.py`: install redaction at startup
- `tests/utils/test_redact.py`: 13 tests (unit + logging integration; f-string and %-style records; clean records keep their args; idempotent install)

## Verification

- full suite: 865 passed, 3 skipped (pre-existing skips)
- ruff check + format: clean · mypy: clean · bandit: no findings

https://claude.ai/code/session_01F4MERCpiV1BP2jGYGUVjAU