### PR TITLE
fix(issue): convert Markdown descriptions to Jira wiki markup on upload

### DIFF
--- a/budjira/services/issues.py
+++ b/budjira/services/issues.py
@@ -9,6 +9,7 @@ from jira.exceptions import JIRAError
 from budjira.models.issue import Issue
 from budjira.services.base import BaseJiraService
 from budjira.utils.errors import InvalidIssueError, JiraAPIError, PermissionError
+from budjira.utils.markdown_to_jira import markdown_to_wiki
 
 
 class IssueService(BaseJiraService):
@@ -175,7 +176,8 @@ class IssueService(BaseJiraService):
             }
 
             if description:
-                fields["description"] = description
+                # Jira REST v2 renders descriptions as wiki markup; convert from Markdown (issue #95).
+                fields["description"] = markdown_to_wiki(description)
             if priority:
                 fields["priority"] = {"name": priority}
             if assignee:
@@ -221,7 +223,7 @@ class IssueService(BaseJiraService):
             # jira's Resource.delete is inherited untyped (unlike the overridden Issue.update). cast() keeps this
             # clean across mypy environments: with jira installed the call would otherwise raise no-untyped-call,
             # while in the jira-less CI mypy env a type: ignore would be flagged unused.
-            cast(Any, self.client.issue(issue_key)).delete(deleteSubtasks=delete_subtasks)
+            cast("Any", self.client.issue(issue_key)).delete(deleteSubtasks=delete_subtasks)
             self._logger.info(f"Deleted issue {issue_key}")
 
         except JIRAError as e:
@@ -292,7 +294,8 @@ class IssueService(BaseJiraService):
 
             # Handle description
             if description is not None:
-                update_fields["description"] = description
+                # Jira REST v2 renders descriptions as wiki markup; convert from Markdown (issue #95).
+                update_fields["description"] = markdown_to_wiki(description)
 
             if update_fields:
                 self.client.issue(issue_key).update(fields=update_fields)

--- a/budjira/utils/markdown_to_jira.py
+++ b/budjira/utils/markdown_to_jira.py
@@ -1,0 +1,121 @@
+"""Convert Markdown to Jira legacy wiki markup.
+
+budjira talks to Jira over REST API v2 (jira-python's default), where the
+``description`` field is a plain string that Jira Cloud renders with the
+**legacy wiki-markup renderer** — not Markdown. Authors naturally write
+Markdown, so headings, checkboxes and bullet lists render as garbage without
+conversion (issue #95).
+
+This module is a pragmatic, contained bridge: it converts the common Markdown
+constructs used in issue descriptions to their wiki-markup equivalents on
+upload. It is deliberately **not** a full Markdown parser. The correct
+long-term fix is moving the client to REST v3 + ADF, tracked as epic #96.
+
+Mapping summary:
+
+===================  ===================
+Markdown             Jira wiki markup
+===================  ===================
+``# H`` .. ``###### `` ``h1.`` .. ``h6.``
+``- x`` / ``+ x``    ``* x`` (bullet)
+``1. x``             ``# x`` (ordered)
+``- [ ] x``          ``* (x) x`` (open)
+``- [x] x``          ``* (/) x`` (done)
+``**b**`` / ``__b__`` ``*b*`` (bold)
+```` `c` ````        ``{{c}}`` (monospace)
+``[t](u)``           ``[t|u]`` (link)
+```` ```lang ````    ``{code:lang}`` fence
+===================  ===================
+
+Underscore italics (``_i_``) already match Jira's syntax and pass through
+unchanged. Single-asterisk Markdown italics are intentionally left alone to
+avoid clobbering bullet markers.
+"""
+
+import re
+
+_FENCE_RE = re.compile(r"^```(.*)$")
+_CHECKBOX_RE = re.compile(r"^(\s*)[-*+] \[([ xX])\] (.*)$")
+_HEADING_RE = re.compile(r"^(#{1,6}) (.*)$")
+_ORDERED_RE = re.compile(r"^(\s*)\d+\. (.*)$")
+_BULLET_RE = re.compile(r"^(\s*)[-*+] (.*)$")
+
+_INLINE_CODE_RE = re.compile(r"`([^`]+)`")
+_BOLD_STAR_RE = re.compile(r"\*\*(.+?)\*\*")
+_BOLD_UNDERSCORE_RE = re.compile(r"__(.+?)__")
+_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+
+
+def _inline(text: str) -> str:
+    """Apply inline (span-level) Markdown -> wiki conversions."""
+    text = _INLINE_CODE_RE.sub(r"{{\1}}", text)
+    text = _BOLD_STAR_RE.sub(r"*\1*", text)
+    text = _BOLD_UNDERSCORE_RE.sub(r"*\1*", text)
+    text = _LINK_RE.sub(r"[\1|\2]", text)
+    return text
+
+
+def _convert_line(line: str) -> str:
+    """Convert a single non-fenced line (block prefix + inline content)."""
+    checkbox = _CHECKBOX_RE.match(line)
+    if checkbox:
+        indent, mark, rest = checkbox.groups()
+        depth = len(indent) // 2 + 1
+        icon = "(/)" if mark in "xX" else "(x)"
+        return "*" * depth + f" {icon} " + _inline(rest)
+
+    heading = _HEADING_RE.match(line)
+    if heading:
+        hashes, rest = heading.groups()
+        return f"h{len(hashes)}. " + _inline(rest)
+
+    ordered = _ORDERED_RE.match(line)
+    if ordered:
+        indent, rest = ordered.groups()
+        depth = len(indent) // 2 + 1
+        return "#" * depth + " " + _inline(rest)
+
+    bullet = _BULLET_RE.match(line)
+    if bullet:
+        indent, rest = bullet.groups()
+        depth = len(indent) // 2 + 1
+        return "*" * depth + " " + _inline(rest)
+
+    return _inline(line)
+
+
+def markdown_to_wiki(text: str) -> str:
+    """Convert a Markdown string to Jira legacy wiki markup.
+
+    Content inside fenced code blocks (```` ``` ````) is emitted verbatim,
+    wrapped in a ``{code}`` block. Empty input is returned unchanged.
+
+    Args:
+        text: Markdown source (e.g. an issue description).
+
+    Returns:
+        The equivalent Jira wiki-markup string.
+    """
+    if not text:
+        return text
+
+    out: list[str] = []
+    in_fence = False
+    for line in text.split("\n"):
+        fence = _FENCE_RE.match(line)
+        if fence:
+            if not in_fence:
+                lang = fence.group(1).strip()
+                out.append(f"{{code:{lang}}}" if lang else "{code}")
+                in_fence = True
+            else:
+                out.append("{code}")
+                in_fence = False
+            continue
+
+        if in_fence:
+            out.append(line)
+        else:
+            out.append(_convert_line(line))
+
+    return "\n".join(out)

--- a/tests/services/test_issues.py
+++ b/tests/services/test_issues.py
@@ -1,7 +1,7 @@
 # mypy: disable-error-code="attr-defined,union-attr"
 """Tests for issue service."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from budjira.services.issues import IssueService
@@ -66,3 +66,30 @@ class TestDeleteIssue:
 
         with pytest.raises(JiraAPIError):
             service.delete("PROJ-123")
+
+
+class TestDescriptionConversion:
+    """Markdown descriptions must be converted to Jira wiki markup on upload."""
+
+    def test_create_converts_markdown_description(self) -> None:
+        """create() sends wiki markup, not raw Markdown (issue #95)."""
+        mock_client = MagicMock()
+        service = IssueService(mock_client)
+
+        with patch("budjira.services.issues.Issue.from_jira_issue", return_value=MagicMock()):
+            service.create("PROJ", "summary", "Task", description="## Title\n- [ ] todo")
+
+        fields = mock_client.create_issue.call_args.kwargs["fields"]
+        assert fields["description"] == "h2. Title\n* (x) todo"
+
+    def test_update_converts_markdown_description(self) -> None:
+        """update() sends wiki markup, not raw Markdown (issue #95)."""
+        mock_client = MagicMock()
+        mock_issue = MagicMock()
+        mock_client.issue.return_value = mock_issue
+        service = IssueService(mock_client)
+
+        service.update("PROJ-1", description="## Title\n- [ ] todo")
+
+        fields = mock_issue.update.call_args.kwargs["fields"]
+        assert fields["description"] == "h2. Title\n* (x) todo"

--- a/tests/utils/test_markdown_to_jira.py
+++ b/tests/utils/test_markdown_to_jira.py
@@ -1,0 +1,110 @@
+"""Tests for Markdown -> Jira wiki-markup conversion.
+
+budjira uploads issue descriptions verbatim over REST API v2, where Jira Cloud
+renders them with the legacy wiki-markup renderer. Authors write Markdown, so
+without conversion headings, checkboxes and bullet lists render as garbage
+(see issue #95). ``markdown_to_wiki`` bridges that gap until the client moves
+to REST v3 + ADF (see epic #96).
+"""
+
+from budjira.utils.markdown_to_jira import markdown_to_wiki
+
+
+class TestHeadings:
+    def test_h1(self) -> None:
+        assert markdown_to_wiki("# Title") == "h1. Title"
+
+    def test_h2(self) -> None:
+        assert markdown_to_wiki("## Description") == "h2. Description"
+
+    def test_h6(self) -> None:
+        assert markdown_to_wiki("###### Deep") == "h6. Deep"
+
+    def test_hash_without_space_is_not_a_heading(self) -> None:
+        # "#tag" is not a Markdown heading and must not become "h1."
+        assert markdown_to_wiki("#tag stays literal") == "#tag stays literal"
+
+    def test_more_than_six_hashes_is_not_a_heading(self) -> None:
+        assert markdown_to_wiki("####### too deep") == "####### too deep"
+
+
+class TestLists:
+    def test_dash_bullet(self) -> None:
+        assert markdown_to_wiki("- item") == "* item"
+
+    def test_plus_bullet(self) -> None:
+        assert markdown_to_wiki("+ item") == "* item"
+
+    def test_asterisk_bullet_passthrough(self) -> None:
+        assert markdown_to_wiki("* item") == "* item"
+
+    def test_nested_bullet(self) -> None:
+        assert markdown_to_wiki("  - nested") == "** nested"
+
+    def test_ordered_list(self) -> None:
+        assert markdown_to_wiki("1. first") == "# first"
+
+    def test_ordered_list_multi_digit(self) -> None:
+        assert markdown_to_wiki("10. tenth") == "# tenth"
+
+
+class TestCheckboxes:
+    def test_unchecked(self) -> None:
+        assert markdown_to_wiki("- [ ] todo") == "* (x) todo"
+
+    def test_checked_lower(self) -> None:
+        assert markdown_to_wiki("- [x] done") == "* (/) done"
+
+    def test_checked_upper(self) -> None:
+        assert markdown_to_wiki("- [X] done") == "* (/) done"
+
+
+class TestInline:
+    def test_bold_double_star(self) -> None:
+        assert markdown_to_wiki("a **bold** word") == "a *bold* word"
+
+    def test_bold_double_underscore(self) -> None:
+        assert markdown_to_wiki("a __bold__ word") == "a *bold* word"
+
+    def test_inline_code(self) -> None:
+        assert markdown_to_wiki("call `foo()` now") == "call {{foo()}} now"
+
+    def test_link(self) -> None:
+        assert markdown_to_wiki("see [docs](https://x.io)") == "see [docs|https://x.io]"
+
+    def test_underscore_italic_passthrough(self) -> None:
+        # Jira italic already uses underscores, so _italic_ needs no change.
+        assert markdown_to_wiki("an _italic_ word") == "an _italic_ word"
+
+
+class TestCodeFences:
+    def test_fenced_block_with_language(self) -> None:
+        md = "```python\nx = 1\n```"
+        assert markdown_to_wiki(md) == "{code:python}\nx = 1\n{code}"
+
+    def test_fenced_block_plain(self) -> None:
+        md = "```\nplain\n```"
+        assert markdown_to_wiki(md) == "{code}\nplain\n{code}"
+
+    def test_no_inline_conversion_inside_fence(self) -> None:
+        # Markdown-looking content inside a fence stays verbatim.
+        md = "```\n# not a heading\n- **not bold**\n```"
+        assert markdown_to_wiki(md) == "{code}\n# not a heading\n- **not bold**\n{code}"
+
+
+class TestPassthrough:
+    def test_empty_string(self) -> None:
+        assert markdown_to_wiki("") == ""
+
+    def test_plain_text_unchanged(self) -> None:
+        assert markdown_to_wiki("Just a sentence.") == "Just a sentence."
+
+    def test_multiline_plain_text(self) -> None:
+        assert markdown_to_wiki("line one\n\nline two") == "line one\n\nline two"
+
+
+class TestRealisticDorDescription:
+    def test_issue_95_example(self) -> None:
+        md = "## Description\n\nSome text.\n\n## Acceptance Criteria\n\n- [ ] first\n- [x] second"
+        expected = "h2. Description\n\nSome text.\n\nh2. Acceptance Criteria\n\n* (x) first\n* (/) second"
+        assert markdown_to_wiki(md) == expected


### PR DESCRIPTION
## Summary

budjira talks to Jira over REST API v2, where the `description` field is rendered
with the **legacy wiki-markup renderer**. Descriptions were uploaded verbatim, so
Markdown that authors naturally write rendered as garbage — `## Description` became
a `1. → a.` numbered outline and `- [ ]` rendered as literal `[ ]` text (issue #95).

This PR adds a **contained Markdown → Jira wiki-markup converter** and applies it on
the description write paths. It is the pragmatic v2 workaround; the correct long-term
fix (REST v3 + ADF, which affects far more than descriptions) is tracked as epic #96.

## Changes

- new `budjira/utils/markdown_to_jira.py`: `markdown_to_wiki()` — headings (`# `→`h1.`),
  bullet/ordered lists, task checkboxes (`- [ ]`→`* (x)`, `- [x]`→`* (/)`), bold,
  inline code, links, fenced code blocks (verbatim inside `{code}`)
- `budjira/services/issues.py`: convert description on `create()` and `update()`
- tests: 26 converter unit tests + 2 service wiring tests

## Why the service layer

DoR validation runs upstream in the CLI on the **raw Markdown**, so its `^## ` section
markers still match. Conversion happens inside `IssueService`, after DoR — so a
DoR-compliant create both passes validation and renders correctly.

## Scope

Descriptions only (create + update), matching issue #95. Comment/worklog/link bodies
have the same v2 wiki-markup behavior and are listed as part of the broader v3 work in
#96; the converter is generic and can be applied there later.

## Verification

- full suite: 893 passed, 3 skipped (pre-existing)
- ruff check + format: clean · mypy: clean · bandit: no findings

Closes #95
Part of #96
