### PR TITLE
fix(install): gate update on .git checkout and self-heal non-git dir

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -38,7 +38,7 @@ BIN_DIR="$HOME/.local/bin"
 
 echo "${YELLOW}→${NC} Installing budjira to ${INSTALL_DIR}..."
 
-if [ -d "$INSTALL_DIR" ]; then
+if [ -d "$INSTALL_DIR/.git" ]; then
     echo "${YELLOW}→${NC} Updating existing installation..."
     cd "$INSTALL_DIR"
     # Reset any local changes and force-sync with remote
@@ -47,7 +47,15 @@ if [ -d "$INSTALL_DIR" ]; then
     git reset --hard origin/master --quiet
     git clean -fd --quiet
 else
-    echo "${YELLOW}→${NC} Cloning budjira repository..."
+    # Gate on the .git checkout, not just the directory: a directory that exists
+    # but is not a git checkout (interrupted/corrupted earlier install) would make
+    # git fetch abort with "not a git repository". Heal it by re-cloning.
+    if [ -d "$INSTALL_DIR" ]; then
+        echo "${YELLOW}→${NC} Existing directory is not a git checkout, re-cloning..."
+        rm -rf "$INSTALL_DIR"
+    else
+        echo "${YELLOW}→${NC} Cloning budjira repository..."
+    fi
     mkdir -p "$(dirname "$INSTALL_DIR")"
     git clone --quiet https://github.com/cdds-ab/budjira.git "$INSTALL_DIR"
     cd "$INSTALL_DIR"


### PR DESCRIPTION
## Summary

`budjira update` failed with `fatal: not a git repository (or any of the parent
directories): .git`.

`install.sh` gated its update path on **directory existence**
(`[ -d "$INSTALL_DIR" ]`), not on the directory being a git checkout. When
`~/.local/share/budjira` existed but had no `.git` (interrupted or corrupted
earlier install), the update branch ran `git fetch` in a non-repo and aborted.

## Fix

- Gate on `$INSTALL_DIR/.git` instead of `$INSTALL_DIR`.
- Self-heal: if a non-git directory exists, remove it and re-clone.
- Valid-checkout update path and fresh-clone path are unchanged.

## Verification

Branch-selection tested with a stubbed `git` for all three states:

| State | Branch taken | Result |
|-------|--------------|--------|
| non-git dir exists (the bug) | heal → `rm -rf` + clone | no crash, `.git` present |
| valid git checkout | update (fetch/reset/clean) | unchanged |
| nothing exists | fresh clone | `.git` present |

`sh -n install.sh` clean.

## No release needed

`install.sh` is fetched live from `master` at update time (hardcoded URL in
`budjira/utils/version.py:174`) and is not part of the installed package. The fix
takes effect for every `budjira update` as soon as it lands on `master` — no
version bump.

## Workaround until merged

```sh
rm -rf ~/.local/share/budjira
curl -LsSf https://raw.githubusercontent.com/cdds-ab/budjira/master/install.sh | sh
```

Closes #98
Related: #99 (update ignores install method — separate, broader issue)
