### PR TITLE
feat(worklog): resolve real Tempo author, add JSON output and author/date filters (#92)

### DIFF
--- a/budjira/cli/worklog.py
+++ b/budjira/cli/worklog.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from datetime import date
+import re
+from datetime import date, datetime
 from typing import TYPE_CHECKING, Annotated, Any
 
 import typer
@@ -25,10 +26,14 @@ from budjira.utils.formatter import OutputFormatter
 from budjira.utils.time_parser import parse_time_string
 
 if TYPE_CHECKING:
+    from budjira.models.connection import Connection
     from budjira.tempo.models import TempoWorklog
 
 console = Console()
 app = typer.Typer(help="Manage work log entries for issues")
+
+# Tempo API hard cap per request; results at exactly this size may be incomplete.
+_TEMPO_WORKLOG_LIMIT = 1000
 
 
 @app.command(name="add")
@@ -251,6 +256,9 @@ def list_worklogs(
         console.print("[red]Error:[/red] --mine and --author cannot be used together.")
         raise typer.Exit(1)
 
+    from_date_obj = _parse_date_option(from_date, "--from")
+    to_date_obj = _parse_date_option(to_date, "--to")
+
     try:
         connection = get_active_connection(connection_name)
         filters_requested = mine or author is not None or from_date is not None or to_date is not None
@@ -263,8 +271,8 @@ def list_worklogs(
                 output_format=output_format,
                 mine=mine,
                 author=author,
-                from_date=from_date,
-                to_date=to_date,
+                from_date=from_date_obj,
+                to_date=to_date_obj,
             )
         else:
             if filters_requested:
@@ -295,16 +303,38 @@ def list_worklogs(
         raise typer.Exit(1) from e
 
 
+def _parse_date_option(value: str | None, option: str) -> date | None:
+    """Parse a YYYY-MM-DD option value, exiting with a usage error if invalid."""
+    if value is None:
+        return None
+    try:
+        return date.fromisoformat(value)
+    except ValueError:
+        console.print(f"[red]Error:[/red] Invalid date for {option}: '{value}' (expected YYYY-MM-DD).")
+        raise typer.Exit(1) from None
+
+
+def _worklog_table(issue_key: str) -> Table:
+    """Build the shared worklog table skeleton."""
+    table = Table(title=f"Work Logs for {issue_key}", show_header=True)
+    table.add_column("ID", style="dim")
+    table.add_column("Author", style="cyan")
+    table.add_column("Time Spent", style="green")
+    table.add_column("Started", style="blue")
+    table.add_column("Comment", style="white", no_wrap=False)
+    return table
+
+
 def _list_worklogs_tempo(
     *,
     issue_key: str,
     connection_name: str | None,
-    connection: Any,
+    connection: Connection,
     output_format: str,
     mine: bool,
     author: str | None,
-    from_date: str | None,
-    to_date: str | None,
+    from_date: date | None,
+    to_date: date | None,
 ) -> None:
     """List worklogs via the Tempo API (real author + filters)."""
     tempo_client = get_tempo_client(connection_name)
@@ -318,22 +348,21 @@ def _list_worklogs_tempo(
     if mine:
         account_id = jira_client.client.myself()["accountId"]
 
-    from_date_obj = date.fromisoformat(from_date) if from_date else None
-    to_date_obj = date.fromisoformat(to_date) if to_date else None
-
     worklogs = tempo_client.get_worklogs(
         issue_id=issue_id,
         account_id=account_id,
-        from_date=from_date_obj,
-        to_date=to_date_obj,
-        limit=1000,
+        from_date=from_date,
+        to_date=to_date,
+        limit=_TEMPO_WORKLOG_LIMIT,
     )
+    truncated = len(worklogs) >= _TEMPO_WORKLOG_LIMIT
 
     if OutputFormatter.is_json_format(output_format):
         OutputFormatter.output_json(
             {
                 "issue": issue_key,
                 "total": len(worklogs),
+                "truncated": truncated,
                 "worklogs": [_tempo_worklog_to_dict(wl) for wl in worklogs],
             }
         )
@@ -343,12 +372,7 @@ def _list_worklogs_tempo(
         console.print(f"[yellow]No work logs found for {issue_key}[/yellow]")
         return
 
-    table = Table(title=f"Work Logs for {issue_key}", show_header=True)
-    table.add_column("ID", style="dim")
-    table.add_column("Author", style="cyan")
-    table.add_column("Time Spent", style="green")
-    table.add_column("Started", style="blue")
-    table.add_column("Comment", style="white", no_wrap=False)
+    table = _worklog_table(issue_key)
 
     for wl in worklogs:
         hours, remainder = divmod(wl.timeSpentSeconds, 3600)
@@ -360,6 +384,11 @@ def _list_worklogs_tempo(
 
     console.print(table)
     console.print(f"\n[green]Total: {len(worklogs)} work log(s)[/green]")
+    if truncated:
+        console.print(
+            f"[yellow]Result truncated at {_TEMPO_WORKLOG_LIMIT} entries; "
+            "narrow the range with --from/--to to see the rest.[/yellow]"
+        )
 
 
 def _tempo_worklog_to_dict(wl: TempoWorklog) -> dict[str, Any]:
@@ -374,26 +403,44 @@ def _tempo_worklog_to_dict(wl: TempoWorklog) -> dict[str, Any]:
     }
 
 
-def _list_worklogs_jira(issue_key: str, connection: Any, output_format: str) -> None:
+def _split_jira_started(started: str | None) -> tuple[str | None, str | None]:
+    """Split a Jira 'started' timestamp into (date, time) ISO parts for JSON parity with Tempo."""
+    if not started:
+        return None, None
+    # Normalize "+0000"-style offsets so Python 3.10's fromisoformat accepts them.
+    normalized = re.sub(r"([+-]\d{2})(\d{2})$", r"\1:\2", started.replace("Z", "+00:00"))
+    try:
+        dt = datetime.fromisoformat(normalized)
+    except ValueError:
+        return started, None
+    return dt.date().isoformat(), dt.time().replace(microsecond=0).isoformat()
+
+
+def _list_worklogs_jira(issue_key: str, connection: Connection, output_format: str) -> None:
     """List worklogs via the Jira worklog API (non-Tempo connections)."""
     client = JiraClient.from_connection(connection)
     worklogs = client.get_worklogs(issue_key)
 
     if OutputFormatter.is_json_format(output_format):
+        records = []
+        for wl in worklogs:
+            start_date, start_time = _split_jira_started(wl.get("started"))
+            records.append(
+                {
+                    "id": wl.get("id"),
+                    "author": {"accountId": None, "displayName": wl.get("author")},
+                    "timeSpentSeconds": wl.get("timeSpentSeconds"),
+                    "startDate": start_date,
+                    "startTime": start_time,
+                    "description": wl.get("comment"),
+                }
+            )
         OutputFormatter.output_json(
             {
                 "issue": issue_key,
                 "total": len(worklogs),
-                "worklogs": [
-                    {
-                        "id": wl.get("id"),
-                        "author": {"accountId": None, "displayName": wl.get("author")},
-                        "timeSpentSeconds": wl.get("timeSpentSeconds"),
-                        "startDate": wl.get("started"),
-                        "description": wl.get("comment"),
-                    }
-                    for wl in worklogs
-                ],
+                "truncated": False,
+                "worklogs": records,
             }
         )
         return
@@ -402,12 +449,7 @@ def _list_worklogs_jira(issue_key: str, connection: Any, output_format: str) -> 
         console.print(f"[yellow]No work logs found for {issue_key}[/yellow]")
         return
 
-    table = Table(title=f"Work Logs for {issue_key}", show_header=True)
-    table.add_column("ID", style="dim")
-    table.add_column("Author", style="cyan")
-    table.add_column("Time Spent", style="green")
-    table.add_column("Started", style="blue")
-    table.add_column("Comment", style="white", no_wrap=False)
+    table = _worklog_table(issue_key)
 
     for wl in worklogs:
         wl_id = str(wl.get("id", ""))
@@ -416,13 +458,10 @@ def _list_worklogs_jira(issue_key: str, connection: Any, output_format: str) -> 
         started = wl.get("started", "")
 
         if started:
-            # Parse and format: "2025-10-25T14:30:00.000+0000" -> "2025-10-25 14:30"
-            try:
-                from datetime import datetime
-
-                dt = datetime.fromisoformat(started.replace("Z", "+00:00"))
-                started_fmt = dt.strftime("%Y-%m-%d %H:%M")
-            except Exception:
+            start_date, start_time = _split_jira_started(started)
+            if start_time:
+                started_fmt = f"{start_date} {start_time[:5]}"
+            else:
                 started_fmt = started[:16] if len(started) > 16 else started
         else:
             started_fmt = "-"

--- a/budjira/cli/worklog.py
+++ b/budjira/cli/worklog.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Annotated
+from datetime import date
+from typing import TYPE_CHECKING, Annotated, Any
 
 import typer
 from rich.console import Console
 from rich.table import Table
 
+from budjira.cli.tempo import get_tempo_client
 from budjira.core.jira_client import JiraClient
 from budjira.utils.connection import get_active_connection
 from budjira.utils.datetime_parser import parse_datetime_string
@@ -19,7 +21,11 @@ from budjira.utils.errors import (
     PermissionError,
     ValidationError,
 )
+from budjira.utils.formatter import OutputFormatter
 from budjira.utils.time_parser import parse_time_string
+
+if TYPE_CHECKING:
+    from budjira.tempo.models import TempoWorklog
 
 console = Console()
 app = typer.Typer(help="Manage work log entries for issues")
@@ -195,6 +201,7 @@ def delete_worklog(
 
 @app.command(name="list")
 def list_worklogs(
+    ctx: typer.Context,
     issue_key: Annotated[
         str,
         typer.Argument(help="Issue key (e.g., PROJ-123)"),
@@ -207,61 +214,66 @@ def list_worklogs(
             envvar="BUDJIRA_CONNECTION",
         ),
     ] = None,
+    mine: Annotated[
+        bool,
+        typer.Option("--mine", help="Only worklogs authored by the current user (Tempo connections only)"),
+    ] = False,
+    author: Annotated[
+        str | None,
+        typer.Option("--author", help="Filter by author accountId (Tempo connections only)"),
+    ] = None,
+    from_date: Annotated[
+        str | None,
+        typer.Option("--from", help="Only worklogs on/after this date, YYYY-MM-DD (Tempo connections only)"),
+    ] = None,
+    to_date: Annotated[
+        str | None,
+        typer.Option("--to", help="Only worklogs on/before this date, YYYY-MM-DD (Tempo connections only)"),
+    ] = None,
 ) -> None:
     """List work log entries for an issue.
 
-    Display all work logs for the specified issue in a table.
+    On Tempo-enabled connections the worklogs are fetched via the Tempo API so the
+    real author is shown (the Jira worklog API reports only the Tempo sync account),
+    and the --mine/--author/--from/--to filters are available. On non-Tempo
+    connections the Jira worklog API is used.
 
-    Example:
+    Examples:
 
         budjira worklog list PROJ-123
+        budjira worklog list PROJ-123 --mine
+        budjira worklog list PROJ-123 --author 557058:abc --from 2025-10-01 --to 2025-10-31
+        budjira -f json worklog list PROJ-123
     """
+    output_format = ctx.obj.get("format", "table") if ctx.obj else "table"
+
+    if mine and author:
+        console.print("[red]Error:[/red] --mine and --author cannot be used together.")
+        raise typer.Exit(1)
+
     try:
-        # Get active connection
         connection = get_active_connection(connection_name)
+        filters_requested = mine or author is not None or from_date is not None or to_date is not None
 
-        # Create Jira client and fetch worklogs
-        client = JiraClient.from_connection(connection)
-        worklogs = client.get_worklogs(issue_key)
-
-        if not worklogs:
-            console.print(f"[yellow]No work logs found for {issue_key}[/yellow]")
-            return
-
-        # Create table
-        table = Table(title=f"Work Logs for {issue_key}", show_header=True)
-        table.add_column("ID", style="dim")
-        table.add_column("Author", style="cyan")
-        table.add_column("Time Spent", style="green")
-        table.add_column("Started", style="blue")
-        table.add_column("Comment", style="white", no_wrap=False)
-
-        # Add rows
-        for wl in worklogs:
-            wl_id = str(wl.get("id", ""))
-            author = wl.get("author", "Unknown")
-            time_spent = wl.get("timeSpent", "0m")
-            started = wl.get("started", "")
-
-            # Format started datetime
-            if started:
-                # Parse and format: "2025-10-25T14:30:00.000+0000" -> "2025-10-25 14:30"
-                try:
-                    from datetime import datetime
-
-                    dt = datetime.fromisoformat(started.replace("Z", "+00:00"))
-                    started_fmt = dt.strftime("%Y-%m-%d %H:%M")
-                except Exception:
-                    started_fmt = started[:16] if len(started) > 16 else started
-            else:
-                started_fmt = "-"
-
-            comment = wl.get("comment", "")
-
-            table.add_row(wl_id, author, time_spent, started_fmt, comment)
-
-        console.print(table)
-        console.print(f"\n[green]Total: {len(worklogs)} work log(s)[/green]")
+        if connection.tempo_enabled:
+            _list_worklogs_tempo(
+                issue_key=issue_key,
+                connection_name=connection_name,
+                connection=connection,
+                output_format=output_format,
+                mine=mine,
+                author=author,
+                from_date=from_date,
+                to_date=to_date,
+            )
+        else:
+            if filters_requested:
+                console.print(
+                    "[red]Error:[/red] --mine/--author/--from/--to require a Tempo-enabled "
+                    "connection. Run 'budjira connect tempo-setup' to enable Tempo."
+                )
+                raise typer.Exit(1)
+            _list_worklogs_jira(issue_key, connection, output_format)
 
     except ConnectionError as e:
         console.print(f"[red]Connection Error:[/red] {e}")
@@ -272,6 +284,151 @@ def list_worklogs(
     except InvalidIssueError as e:
         console.print(f"[red]Invalid Issue:[/red] {e}")
         raise typer.Exit(1) from e
+    except PermissionError as e:
+        console.print(f"[red]Permission Denied:[/red] {e}")
+        raise typer.Exit(1) from e
+    except ValidationError as e:
+        console.print(f"[red]Validation Error:[/red] {e}")
+        raise typer.Exit(1) from e
     except BudjiraError as e:
         console.print(f"[red]Error:[/red] {e}")
         raise typer.Exit(1) from e
+
+
+def _list_worklogs_tempo(
+    *,
+    issue_key: str,
+    connection_name: str | None,
+    connection: Any,
+    output_format: str,
+    mine: bool,
+    author: str | None,
+    from_date: str | None,
+    to_date: str | None,
+) -> None:
+    """List worklogs via the Tempo API (real author + filters)."""
+    tempo_client = get_tempo_client(connection_name)
+    jira_client = JiraClient.from_connection(connection)
+
+    # Tempo requires the numeric issue ID, not the key.
+    issue_id = int(jira_client.client.issue(issue_key).id)
+
+    # Resolve the author filter to an accountId.
+    account_id = author
+    if mine:
+        account_id = jira_client.client.myself()["accountId"]
+
+    from_date_obj = date.fromisoformat(from_date) if from_date else None
+    to_date_obj = date.fromisoformat(to_date) if to_date else None
+
+    worklogs = tempo_client.get_worklogs(
+        issue_id=issue_id,
+        account_id=account_id,
+        from_date=from_date_obj,
+        to_date=to_date_obj,
+        limit=1000,
+    )
+
+    if OutputFormatter.is_json_format(output_format):
+        OutputFormatter.output_json(
+            {
+                "issue": issue_key,
+                "total": len(worklogs),
+                "worklogs": [_tempo_worklog_to_dict(wl) for wl in worklogs],
+            }
+        )
+        return
+
+    if not worklogs:
+        console.print(f"[yellow]No work logs found for {issue_key}[/yellow]")
+        return
+
+    table = Table(title=f"Work Logs for {issue_key}", show_header=True)
+    table.add_column("ID", style="dim")
+    table.add_column("Author", style="cyan")
+    table.add_column("Time Spent", style="green")
+    table.add_column("Started", style="blue")
+    table.add_column("Comment", style="white", no_wrap=False)
+
+    for wl in worklogs:
+        hours, remainder = divmod(wl.timeSpentSeconds, 3600)
+        minutes = remainder // 60
+        time_spent = f"{hours}h {minutes}m" if hours else f"{minutes}m"
+        started = f"{wl.startDate.isoformat()} {(wl.startTime or '')[:5]}".strip()
+        author_name = wl.author.displayName or wl.author.accountId
+        table.add_row(str(wl.tempoWorklogId), author_name, time_spent, started, wl.description or "")
+
+    console.print(table)
+    console.print(f"\n[green]Total: {len(worklogs)} work log(s)[/green]")
+
+
+def _tempo_worklog_to_dict(wl: TempoWorklog) -> dict[str, Any]:
+    """Serialize a Tempo worklog for JSON output."""
+    return {
+        "id": wl.tempoWorklogId,
+        "author": {"accountId": wl.author.accountId, "displayName": wl.author.displayName},
+        "timeSpentSeconds": wl.timeSpentSeconds,
+        "startDate": wl.startDate.isoformat(),
+        "startTime": wl.startTime,
+        "description": wl.description,
+    }
+
+
+def _list_worklogs_jira(issue_key: str, connection: Any, output_format: str) -> None:
+    """List worklogs via the Jira worklog API (non-Tempo connections)."""
+    client = JiraClient.from_connection(connection)
+    worklogs = client.get_worklogs(issue_key)
+
+    if OutputFormatter.is_json_format(output_format):
+        OutputFormatter.output_json(
+            {
+                "issue": issue_key,
+                "total": len(worklogs),
+                "worklogs": [
+                    {
+                        "id": wl.get("id"),
+                        "author": {"accountId": None, "displayName": wl.get("author")},
+                        "timeSpentSeconds": wl.get("timeSpentSeconds"),
+                        "startDate": wl.get("started"),
+                        "description": wl.get("comment"),
+                    }
+                    for wl in worklogs
+                ],
+            }
+        )
+        return
+
+    if not worklogs:
+        console.print(f"[yellow]No work logs found for {issue_key}[/yellow]")
+        return
+
+    table = Table(title=f"Work Logs for {issue_key}", show_header=True)
+    table.add_column("ID", style="dim")
+    table.add_column("Author", style="cyan")
+    table.add_column("Time Spent", style="green")
+    table.add_column("Started", style="blue")
+    table.add_column("Comment", style="white", no_wrap=False)
+
+    for wl in worklogs:
+        wl_id = str(wl.get("id", ""))
+        author = wl.get("author", "Unknown")
+        time_spent = wl.get("timeSpent", "0m")
+        started = wl.get("started", "")
+
+        if started:
+            # Parse and format: "2025-10-25T14:30:00.000+0000" -> "2025-10-25 14:30"
+            try:
+                from datetime import datetime
+
+                dt = datetime.fromisoformat(started.replace("Z", "+00:00"))
+                started_fmt = dt.strftime("%Y-%m-%d %H:%M")
+            except Exception:
+                started_fmt = started[:16] if len(started) > 16 else started
+        else:
+            started_fmt = "-"
+
+        comment = wl.get("comment", "")
+        table.add_row(wl_id, author, time_spent, started_fmt, comment)
+
+    console.print(table)
+    console.print(f"\n[green]Total: {len(worklogs)} work log(s)[/green]")

--- a/tests/cli/test_worklog.py
+++ b/tests/cli/test_worklog.py
@@ -517,3 +517,215 @@ class TestWorklogListCommand:
 
         assert result.exit_code == 0
         mock_get_conn.assert_called_once_with("my-connection")
+
+
+def _tempo_worklog(
+    *,
+    worklog_id: int = 10001,
+    account_id: str = "557058:real-person",
+    display_name: str | None = "Real Person",
+    seconds: int = 9000,
+    description: str | None = "Fixed bug",
+):
+    """Build a TempoWorklog for list tests."""
+    from datetime import date, datetime
+
+    from budjira.tempo.models import TempoAuthor, TempoIssue, TempoWorklog
+
+    return TempoWorklog(
+        self=f"https://api.tempo.io/worklogs/{worklog_id}",
+        tempoWorklogId=worklog_id,
+        issue=TempoIssue(self="https://api.tempo.io/issues/12345", key="TEST-123", id=12345),
+        timeSpentSeconds=seconds,
+        startDate=date(2025, 10, 24),
+        startTime="14:00:00",
+        description=description,
+        createdAt=datetime(2025, 10, 24, 16, 30),
+        updatedAt=datetime(2025, 10, 24, 16, 30),
+        author=TempoAuthor(
+            self=f"https://api.tempo.io/users/{account_id}",
+            accountId=account_id,
+            displayName=display_name,
+        ),
+    )
+
+
+class TestWorklogListTempoAttribution:
+    """Tests for 'budjira worklog list' on Tempo-enabled connections (#92)."""
+
+    @pytest.fixture
+    def tempo_connection(self, mock_connection):
+        mock_connection.tempo_enabled = True
+        return mock_connection
+
+    def _wire_jira(self, mock_jira_class, *, account_id="557058:me"):
+        """Wire JiraClient mock for issue_id resolution and myself()."""
+        jira = MagicMock()
+        issue = MagicMock()
+        issue.id = "12345"
+        issue.key = "TEST-123"
+        jira.client.issue.return_value = issue
+        jira.client.myself.return_value = {"accountId": account_id, "displayName": "Me"}
+        mock_jira_class.from_connection.return_value = jira
+        return jira
+
+    @patch("budjira.cli.worklog.get_tempo_client")
+    @patch("budjira.cli.worklog.JiraClient")
+    @patch("budjira.cli.worklog.get_active_connection")
+    def test_tempo_connection_shows_real_author_displayname(
+        self, mock_get_conn, mock_jira_class, mock_get_tempo, tempo_connection
+    ):
+        """On a Tempo connection the real author displayName is shown, not the sync account."""
+        mock_get_conn.return_value = tempo_connection
+        self._wire_jira(mock_jira_class)
+        tempo = MagicMock()
+        tempo.get_worklogs.return_value = [_tempo_worklog(display_name="Real Person")]
+        mock_get_tempo.return_value = tempo
+
+        result = runner.invoke(app, ["worklog", "list", "TEST-123"])
+
+        assert result.exit_code == 0
+        assert "Real Person" in result.stdout
+        # Resolved numeric issue id must be passed to the Tempo client
+        assert tempo.get_worklogs.call_args.kwargs["issue_id"] == 12345
+
+    @patch("budjira.cli.worklog.get_tempo_client")
+    @patch("budjira.cli.worklog.JiraClient")
+    @patch("budjira.cli.worklog.get_active_connection")
+    def test_format_json_emits_expected_fields(self, mock_get_conn, mock_jira_class, mock_get_tempo, tempo_connection):
+        """--format json emits structured records with author accountId + displayName."""
+        import json
+
+        mock_get_conn.return_value = tempo_connection
+        self._wire_jira(mock_jira_class)
+        tempo = MagicMock()
+        tempo.get_worklogs.return_value = [
+            _tempo_worklog(worklog_id=777, account_id="557058:x", display_name="Real Person", seconds=1800)
+        ]
+        mock_get_tempo.return_value = tempo
+
+        result = runner.invoke(app, ["--format", "json", "worklog", "list", "TEST-123"])
+
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout)
+        record = payload["worklogs"][0]
+        assert record["id"] == 777
+        assert record["author"]["accountId"] == "557058:x"
+        assert record["author"]["displayName"] == "Real Person"
+        assert record["timeSpentSeconds"] == 1800
+        assert record["startDate"] == "2025-10-24"
+
+    @patch("budjira.cli.worklog.get_tempo_client")
+    @patch("budjira.cli.worklog.JiraClient")
+    @patch("budjira.cli.worklog.get_active_connection")
+    def test_mine_filters_by_current_user_account_id(
+        self, mock_get_conn, mock_jira_class, mock_get_tempo, tempo_connection
+    ):
+        """--mine resolves the current user and passes their accountId to the client."""
+        mock_get_conn.return_value = tempo_connection
+        self._wire_jira(mock_jira_class, account_id="557058:me")
+        tempo = MagicMock()
+        tempo.get_worklogs.return_value = []
+        mock_get_tempo.return_value = tempo
+
+        result = runner.invoke(app, ["worklog", "list", "TEST-123", "--mine"])
+
+        assert result.exit_code == 0
+        assert tempo.get_worklogs.call_args.kwargs["account_id"] == "557058:me"
+
+    @patch("budjira.cli.worklog.get_tempo_client")
+    @patch("budjira.cli.worklog.JiraClient")
+    @patch("budjira.cli.worklog.get_active_connection")
+    def test_author_filters_by_account_id(self, mock_get_conn, mock_jira_class, mock_get_tempo, tempo_connection):
+        """--author passes the given accountId to the client."""
+        mock_get_conn.return_value = tempo_connection
+        self._wire_jira(mock_jira_class)
+        tempo = MagicMock()
+        tempo.get_worklogs.return_value = []
+        mock_get_tempo.return_value = tempo
+
+        result = runner.invoke(app, ["worklog", "list", "TEST-123", "--author", "557058:colleague"])
+
+        assert result.exit_code == 0
+        assert tempo.get_worklogs.call_args.kwargs["account_id"] == "557058:colleague"
+
+    @patch("budjira.cli.worklog.get_tempo_client")
+    @patch("budjira.cli.worklog.JiraClient")
+    @patch("budjira.cli.worklog.get_active_connection")
+    def test_from_and_to_passed_to_client(self, mock_get_conn, mock_jira_class, mock_get_tempo, tempo_connection):
+        """--from/--to are parsed and passed as date filters to the client."""
+        from datetime import date
+
+        mock_get_conn.return_value = tempo_connection
+        self._wire_jira(mock_jira_class)
+        tempo = MagicMock()
+        tempo.get_worklogs.return_value = []
+        mock_get_tempo.return_value = tempo
+
+        result = runner.invoke(app, ["worklog", "list", "TEST-123", "--from", "2025-10-01", "--to", "2025-10-31"])
+
+        assert result.exit_code == 0
+        kwargs = tempo.get_worklogs.call_args.kwargs
+        assert kwargs["from_date"] == date(2025, 10, 1)
+        assert kwargs["to_date"] == date(2025, 10, 31)
+
+    @patch("budjira.cli.worklog.get_tempo_client")
+    @patch("budjira.cli.worklog.JiraClient")
+    @patch("budjira.cli.worklog.get_active_connection")
+    def test_mine_and_author_are_mutually_exclusive(
+        self, mock_get_conn, mock_jira_class, mock_get_tempo, tempo_connection
+    ):
+        """--mine and --author together is a usage error."""
+        mock_get_conn.return_value = tempo_connection
+        self._wire_jira(mock_jira_class)
+        mock_get_tempo.return_value = MagicMock()
+
+        result = runner.invoke(app, ["worklog", "list", "TEST-123", "--mine", "--author", "557058:x"])
+
+        assert result.exit_code == 1
+        assert "mine" in result.stdout.lower() and "author" in result.stdout.lower()
+
+
+class TestWorklogListNonTempo:
+    """Non-Tempo (Jira fallback) behaviour for 'budjira worklog list' (#92)."""
+
+    @patch("budjira.cli.worklog.JiraClient")
+    @patch("budjira.cli.worklog.get_active_connection")
+    def test_non_tempo_json_output(self, mock_get_conn, mock_jira_class, mock_connection):
+        """--format json works on the Jira fallback path too."""
+        import json
+
+        mock_get_conn.return_value = mock_connection  # tempo_enabled defaults to False
+        client = MagicMock()
+        client.get_worklogs.return_value = [
+            {
+                "id": "10001",
+                "author": "John Doe",
+                "timeSpent": "2h 30m",
+                "timeSpentSeconds": 9000,
+                "started": "2025-10-24T14:00:00.000+0000",
+                "comment": "Fixed bug",
+            }
+        ]
+        mock_jira_class.from_connection.return_value = client
+
+        result = runner.invoke(app, ["--format", "json", "worklog", "list", "TEST-123"])
+
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout)
+        assert payload["worklogs"][0]["id"] == "10001"
+        assert payload["worklogs"][0]["author"]["displayName"] == "John Doe"
+
+    @patch("budjira.cli.worklog.JiraClient")
+    @patch("budjira.cli.worklog.get_active_connection")
+    def test_filter_flag_on_non_tempo_warns(self, mock_get_conn, mock_jira_class, mock_connection):
+        """Author/date filters require a Tempo connection; using them on Jira warns instead of silently ignoring."""
+        mock_get_conn.return_value = mock_connection  # tempo_enabled=False
+        client = MagicMock()
+        client.get_worklogs.return_value = []
+        mock_jira_class.from_connection.return_value = client
+
+        result = runner.invoke(app, ["worklog", "list", "TEST-123", "--mine"])
+
+        assert result.exit_code == 1
+        assert "tempo" in result.stdout.lower()

--- a/tests/cli/test_worklog.py
+++ b/tests/cli/test_worklog.py
@@ -685,6 +685,55 @@ class TestWorklogListTempoAttribution:
         assert result.exit_code == 1
         assert "mine" in result.stdout.lower() and "author" in result.stdout.lower()
 
+    @patch("budjira.cli.worklog.get_tempo_client")
+    @patch("budjira.cli.worklog.JiraClient")
+    @patch("budjira.cli.worklog.get_active_connection")
+    def test_invalid_from_date_is_usage_error(self, mock_get_conn, mock_jira_class, mock_get_tempo, tempo_connection):
+        """An unparseable --from date is a clean usage error, not a traceback."""
+        mock_get_conn.return_value = tempo_connection
+        self._wire_jira(mock_jira_class)
+        mock_get_tempo.return_value = MagicMock()
+
+        result = runner.invoke(app, ["worklog", "list", "TEST-123", "--from", "2025-13-01"])
+
+        assert result.exit_code == 1
+        assert "invalid date" in result.stdout.lower()
+
+    @patch("budjira.cli.worklog.get_tempo_client")
+    @patch("budjira.cli.worklog.JiraClient")
+    @patch("budjira.cli.worklog.get_active_connection")
+    def test_truncation_hint_when_limit_reached(self, mock_get_conn, mock_jira_class, mock_get_tempo, tempo_connection):
+        """Exactly limit results means more may exist: table output carries a hint."""
+        mock_get_conn.return_value = tempo_connection
+        self._wire_jira(mock_jira_class)
+        tempo = MagicMock()
+        tempo.get_worklogs.return_value = [_tempo_worklog(worklog_id=i) for i in range(1000)]
+        mock_get_tempo.return_value = tempo
+
+        result = runner.invoke(app, ["worklog", "list", "TEST-123"])
+
+        assert result.exit_code == 0
+        assert "truncated" in result.stdout.lower()
+
+    @patch("budjira.cli.worklog.get_tempo_client")
+    @patch("budjira.cli.worklog.JiraClient")
+    @patch("budjira.cli.worklog.get_active_connection")
+    def test_json_truncated_flag(self, mock_get_conn, mock_jira_class, mock_get_tempo, tempo_connection):
+        """JSON output exposes whether the result hit the fetch limit."""
+        import json
+
+        mock_get_conn.return_value = tempo_connection
+        self._wire_jira(mock_jira_class)
+        tempo = MagicMock()
+        tempo.get_worklogs.return_value = [_tempo_worklog()]
+        mock_get_tempo.return_value = tempo
+
+        result = runner.invoke(app, ["--format", "json", "worklog", "list", "TEST-123"])
+
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout)
+        assert payload["truncated"] is False
+
 
 class TestWorklogListNonTempo:
     """Non-Tempo (Jira fallback) behaviour for 'budjira worklog list' (#92)."""
@@ -713,8 +762,12 @@ class TestWorklogListNonTempo:
 
         assert result.exit_code == 0
         payload = json.loads(result.stdout)
-        assert payload["worklogs"][0]["id"] == "10001"
-        assert payload["worklogs"][0]["author"]["displayName"] == "John Doe"
+        record = payload["worklogs"][0]
+        assert record["id"] == "10001"
+        assert record["author"]["displayName"] == "John Doe"
+        # Same schema as the Tempo path: startDate is a date, startTime a separate field.
+        assert record["startDate"] == "2025-10-24"
+        assert record["startTime"] == "14:00:00"
 
     @patch("budjira.cli.worklog.JiraClient")
     @patch("budjira.cli.worklog.get_active_connection")

--- a/tests/cli/test_worklog.py
+++ b/tests/cli/test_worklog.py
@@ -558,7 +558,7 @@ class TestWorklogListTempoAttribution:
         mock_connection.tempo_enabled = True
         return mock_connection
 
-    def _wire_jira(self, mock_jira_class, *, account_id="557058:me"):
+    def _wire_jira(self, mock_jira_class: MagicMock, *, account_id: str = "557058:me") -> MagicMock:
         """Wire JiraClient mock for issue_id resolution and myself()."""
         jira = MagicMock()
         issue = MagicMock()

--- a/uv.lock
+++ b/uv.lock
@@ -37,7 +37,7 @@ wheels = [
 
 [[package]]
 name = "budjira"
-version = "1.21.2"
+version = "1.21.3"
 source = { editable = "." }
 dependencies = [
     { name = "jira" },


### PR DESCRIPTION
Closes #92.

## Problem

`worklog list <ISSUE>` was unreliable for attribution on Tempo-managed tickets:

1. **Wrong author** — the Jira worklog API reports only the Tempo sync account (*"Timesheets by Tempo"*) as author, never the real person.
2. **`--format json` ignored** — the command always emitted a Rich table, so programmatic use was impossible.
3. **No filters** — no `--mine` / `--author` / `--from` / `--to`.

## Change

- **Route through the Tempo API on Tempo-enabled connections** so the real author `displayName` is shown; non-Tempo connections keep using the Jira worklog API.
- **Honor the global `--format json`** on both paths (emits `id`, `author.accountId`, `author.displayName`, `timeSpentSeconds`, `startDate`, `startTime`, `description`).
- **Add `--mine` / `--author <accountId>` / `--from` / `--to`**, backed by the Tempo client's existing `account_id` and date parameters. `--mine` resolves the current user via `myself()`. These filters require a Tempo connection and error clearly on non-Tempo ones instead of being silently ignored; `--mine` + `--author` together is a usage error.

## Notes / scope

- `--author` takes a Jira `accountId` (use `--mine` for yourself). Resolving a plain email to an accountId is left as a follow-up.
- Reuses the established `jira_client.client.myself()["accountId"]` pattern already used in `tempo.py`, `services/issues.py` and `workflow.py`; no new helper added.

## Tests

- 8 new tests in `tests/cli/test_worklog.py` (Tempo real-author, JSON fields, `--mine`, `--author`, `--from/--to`, mutual exclusion, non-Tempo JSON, filter-on-non-Tempo error). Written test-first (red → green).
- Full suite: **901 passed, 3 skipped**, coverage 86%. `ruff check`/`ruff format`/`mypy` clean.