### PR TITLE
fix(update): dispatch self-update on detected install method

### DIFF
--- a/.claude/ai-usage-prompt.md
+++ b/.claude/ai-usage-prompt.md
@@ -725,6 +725,7 @@ budjira worklog list ISSUE-KEY
 Display all worklog entries for an issue.
 
 **Output includes:**
+- Worklog ID
 - Author
 - Time spent
 - Started date/time
@@ -733,7 +734,28 @@ Display all worklog entries for an issue.
 **Example:**
 ```bash
 budjira worklog list PROJ-123
-# Shows table of all worklog entries
+# Shows table with ID, author, time, started, comment
+```
+
+### Delete Worklog Entry
+
+```bash
+budjira worklog delete ISSUE-KEY WORKLOG_ID [OPTIONS]
+```
+
+Delete a native Jira worklog entry by its ID. Use `budjira worklog list` to find worklog IDs.
+
+**Options:**
+- `--force`, `-f`: Skip confirmation prompt
+- `--connection`, `-c`: Connection to use
+
+**Examples:**
+```bash
+# Delete with confirmation (shows worklog details first)
+budjira worklog delete PROJ-123 12345
+
+# Delete without confirmation
+budjira worklog delete PROJ-123 12345 --force
 ```
 
 ### Time Estimates
@@ -1407,8 +1429,11 @@ budjira issue update PROJ-456 --remaining-estimate 6h
 # 4. Log more work
 budjira worklog add PROJ-456 3h --comment "Implemented core functionality"
 
-# 5. View all logged time
+# 5. View all logged time (shows worklog IDs)
 budjira worklog list PROJ-456
+
+# 5b. Delete wrong worklog entry
+budjira worklog delete PROJ-456 12345 --force
 
 # 6. Final work log and complete
 budjira issue update PROJ-456 \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -457,18 +457,21 @@ commits.
 
 ## Installation Methods
 
-**Recommended (isolated environment):**
-```bash
-# Using uvx (recommended)
-uvx install budjira
+**budjira is not published to PyPI.** All installs come from the GitHub
+repository, so `pip install budjira` / `pipx install budjira` do not work.
 
-# Using pipx (alternative)
-pipx install budjira
+**Recommended (install script):**
+```bash
+curl -LsSf https://raw.githubusercontent.com/cdds-ab/budjira/master/install.sh | sh
 ```
+Clones into `~/.local/share/budjira` and symlinks the entry point into
+`~/.local/bin`. This is the method the README documents.
 
-**Traditional:**
+**Isolated environment (from the git URL):**
 ```bash
-pip install budjira
+uv tool install git+https://github.com/cdds-ab/budjira.git
+# or
+pipx install git+https://github.com/cdds-ab/budjira.git
 ```
 
 **From source:**
@@ -482,7 +485,7 @@ uv run budjira --help
 ## Self-Update Mechanism
 
 **Version checking:**
-- Queries PyPI JSON API: `https://pypi.org/pypi/budjira/json`
+- Queries the GitHub Releases API: `https://api.github.com/repos/cdds-ab/budjira/releases/latest`
 - Caches result for 24 hours
 - Shows notification if update available
 - Displays what's new from release notes
@@ -491,7 +494,23 @@ uv run budjira --help
 ```bash
 budjira update
 ```
-Detects installation method (uvx/pipx/pip) and runs appropriate update command.
+`perform_update()` detects the install method from the location of the running
+`budjira` package (`detect_install_method()` in `budjira/utils/version.py`) and
+dispatches accordingly:
+
+| Detected layout | Update action |
+|-----------------|---------------|
+| git checkout (any `.git` above the package) | `install.sh` from master |
+| `.../uv/tools/...` | `uv tool upgrade budjira` |
+| `.../pipx/venvs/...` | `pipx upgrade budjira` |
+| anything else | refuses, points at manual update |
+
+The refusal matters: running the install script from an unrecognized install
+would create a *second*, git-clone install that can shadow the real binary
+depending on `PATH` order.
+
+Note that `install.sh` is always fetched live from `master`, so fixes to the
+install script take effect without a release.
 
 ## Common Development Tasks
 

--- a/README.md
+++ b/README.md
@@ -422,6 +422,12 @@ budjira update
 budjira update --check --force
 ```
 
+`budjira update` uses the mechanism that matches your install: the install
+script for a git checkout, `uv tool upgrade` for a `uv tool install`, and
+`pipx upgrade` for a pipx install. If it cannot tell how budjira was installed,
+it stops and asks you to update manually instead of installing a second copy
+that could shadow the first one.
+
 **Troubleshooting: GitHub API Rate Limits**
 
 If you see `403 Client Error: rate limit exceeded` when checking for updates, you need to authenticate with GitHub:

--- a/budjira/cli/update.py
+++ b/budjira/cli/update.py
@@ -36,7 +36,9 @@ def update(
 ) -> None:
     """Check for and install updates.
 
-    By default, downloads and runs the install script to update budjira.
+    By default, updates budjira with the mechanism matching how it was
+    installed (install script, uv tool, or pipx). If the install method cannot
+    be determined, the update is refused rather than guessed.
     Use --check to only check for updates without installing.
     """
     # If a subcommand was called, don't run the default behavior

--- a/budjira/models/ai_prompt.py
+++ b/budjira/models/ai_prompt.py
@@ -1454,7 +1454,9 @@ budjira update
 Interactive update process:
 1. Shows available version and release notes
 2. Asks for confirmation
-3. Runs installation script
+3. Runs the updater matching the install method (install script for a git
+   checkout, `uv tool upgrade` for uv tool, `pipx upgrade` for pipx; refuses
+   if the install method cannot be determined)
 4. Restarts with new version
 
 ### Force Update Check

--- a/budjira/utils/version.py
+++ b/budjira/utils/version.py
@@ -6,7 +6,10 @@ import json
 import logging
 import subprocess  # nosec B404
 from datetime import datetime, timedelta
-from typing import Any
+from enum import Enum
+from itertools import pairwise
+from pathlib import Path
+from typing import Any, ClassVar
 
 import requests
 
@@ -14,6 +17,44 @@ from budjira import __version__
 from budjira.config import get_settings
 
 logger = logging.getLogger(__name__)
+
+
+class InstallMethod(str, Enum):
+    """How the running budjira was installed."""
+
+    GIT_CLONE = "git-clone"
+    UV_TOOL = "uv-tool"
+    PIPX = "pipx"
+    UNKNOWN = "unknown"
+
+
+def detect_install_method(package_path: Path | None = None) -> InstallMethod:
+    """Detect how the running budjira was installed.
+
+    Detection is based on where the ``budjira`` package lives: uv and pipx both
+    place tool environments in recognizable directory layouts, and the install
+    script places a git checkout that carries a ``.git`` directory.
+
+    Args:
+        package_path: Path of the budjira package (defaults to the running one)
+
+    Returns:
+        The detected install method, or ``InstallMethod.UNKNOWN``
+    """
+    resolved = (package_path or Path(__file__).parent.parent).resolve()
+    parts = resolved.parts
+
+    for first, second in pairwise(parts):
+        if (first, second) == ("uv", "tools"):
+            return InstallMethod.UV_TOOL
+        if (first, second) == ("pipx", "venvs"):
+            return InstallMethod.PIPX
+
+    for parent in resolved.parents:
+        if (parent / ".git").exists():
+            return InstallMethod.GIT_CLONE
+
+    return InstallMethod.UNKNOWN
 
 
 class VersionChecker:
@@ -165,18 +206,40 @@ class VersionChecker:
         except (ValueError, AttributeError):
             return False
 
+    INSTALL_SCRIPT_URL = "https://raw.githubusercontent.com/cdds-ab/budjira/master/install.sh"
+
+    UPGRADE_COMMANDS: ClassVar[dict[InstallMethod, list[str]]] = {
+        InstallMethod.UV_TOOL: ["uv", "tool", "upgrade", "budjira"],
+        InstallMethod.PIPX: ["pipx", "upgrade", "budjira"],
+    }
+
     def perform_update(self) -> tuple[bool, str]:
-        """Perform self-update using install script.
+        """Perform self-update using the mechanism matching the install method.
 
         Returns:
             Tuple of (success, message)
         """
-        install_script_url = "https://raw.githubusercontent.com/cdds-ab/budjira/master/install.sh"
+        method = detect_install_method()
+        logger.debug(f"Detected install method: {method.value}")
+
+        if method is InstallMethod.UNKNOWN:
+            # Running the install script here would create a second, git-clone
+            # install that can shadow the real one depending on PATH order.
+            return (
+                False,
+                "Could not determine how budjira was installed, so it was not touched. "
+                "Please update it manually with the tool you installed it with "
+                "(for example 'pip install -U', or re-run the install script from the README).",
+            )
+
+        if method is InstallMethod.GIT_CLONE:
+            command = ["sh", "-c", f"curl -LsSf {self.INSTALL_SCRIPT_URL} | sh"]
+        else:
+            command = self.UPGRADE_COMMANDS[method]
 
         try:
-            # Download and execute install script from official repository
             result = subprocess.run(  # nosec B603 B607
-                ["sh", "-c", f"curl -LsSf {install_script_url} | sh"],
+                command,
                 capture_output=True,
                 text=True,
                 timeout=120,

--- a/tests/utils/test_version.py
+++ b/tests/utils/test_version.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import pytest
-from budjira.utils.version import VersionChecker
+from budjira.utils.version import InstallMethod, VersionChecker, detect_install_method
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -198,7 +198,10 @@ class TestVersionChecker:
         mock_result.stdout = "Update successful"
         mock_result.stderr = ""
 
-        with patch("subprocess.run", return_value=mock_result):
+        with (
+            patch("budjira.utils.version.detect_install_method", return_value=InstallMethod.GIT_CLONE),
+            patch("subprocess.run", return_value=mock_result),
+        ):
             success, message = version_checker.perform_update()
 
             assert success is True
@@ -211,7 +214,10 @@ class TestVersionChecker:
         mock_result.stdout = ""
         mock_result.stderr = "Update failed"
 
-        with patch("subprocess.run", return_value=mock_result):
+        with (
+            patch("budjira.utils.version.detect_install_method", return_value=InstallMethod.GIT_CLONE),
+            patch("subprocess.run", return_value=mock_result),
+        ):
             success, message = version_checker.perform_update()
 
             assert success is False
@@ -221,8 +227,116 @@ class TestVersionChecker:
         """Test update timeout."""
         import subprocess
 
-        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("cmd", 120)):
+        with (
+            patch("budjira.utils.version.detect_install_method", return_value=InstallMethod.GIT_CLONE),
+            patch("subprocess.run", side_effect=subprocess.TimeoutExpired("cmd", 120)),
+        ):
             success, message = version_checker.perform_update()
 
             assert success is False
             assert "timed out" in message.lower()
+
+
+def _make_package(root: Path, *, relative_venv: str) -> Path:
+    """Create a fake installed budjira package tree and return its package dir.
+
+    Args:
+        root: Directory the install lives in
+        relative_venv: Path from root down to the site-packages parent
+
+    Returns:
+        Path of the fake ``budjira`` package directory
+    """
+    package_dir = root / relative_venv / "site-packages" / "budjira"
+    package_dir.mkdir(parents=True)
+    (package_dir / "__init__.py").write_text("")
+    return package_dir
+
+
+class TestDetectInstallMethod:
+    """Test install-method detection from the package location."""
+
+    def test_detects_git_clone_install(self, tmp_path: Path) -> None:
+        """A checkout with a .git directory above the package is a git-clone install."""
+        install_root = tmp_path / ".local" / "share" / "budjira"
+        (install_root / ".git").mkdir(parents=True)
+        package_dir = _make_package(install_root, relative_venv=".venv/lib/python3.13")
+
+        assert detect_install_method(package_dir) is InstallMethod.GIT_CLONE
+
+    def test_detects_uv_tool_install(self, tmp_path: Path) -> None:
+        """A package under uv's tool directory is a uv-tool install."""
+        install_root = tmp_path / ".local" / "share" / "uv" / "tools" / "budjira"
+        package_dir = _make_package(install_root, relative_venv="lib/python3.13")
+
+        assert detect_install_method(package_dir) is InstallMethod.UV_TOOL
+
+    def test_detects_pipx_install(self, tmp_path: Path) -> None:
+        """A package under pipx's venv directory is a pipx install."""
+        install_root = tmp_path / ".local" / "pipx" / "venvs" / "budjira"
+        package_dir = _make_package(install_root, relative_venv="lib/python3.13")
+
+        assert detect_install_method(package_dir) is InstallMethod.PIPX
+
+    def test_detects_unknown_for_plain_site_packages(self, tmp_path: Path) -> None:
+        """A plain pip/system install into site-packages is not recognized."""
+        package_dir = _make_package(tmp_path / "usr", relative_venv="lib/python3.13")
+
+        assert detect_install_method(package_dir) is InstallMethod.UNKNOWN
+
+
+class TestPerformUpdateDispatch:
+    """Test that perform_update dispatches on the detected install method."""
+
+    @staticmethod
+    def _ok_result() -> MagicMock:
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = ""
+        result.stderr = ""
+        return result
+
+    def test_git_clone_runs_install_script(self, version_checker: VersionChecker) -> None:
+        """The git-clone install keeps using the install script."""
+        with (
+            patch("budjira.utils.version.detect_install_method", return_value=InstallMethod.GIT_CLONE),
+            patch("subprocess.run", return_value=self._ok_result()) as mock_run,
+        ):
+            success, _message = version_checker.perform_update()
+
+        assert success is True
+        assert "install.sh" in " ".join(mock_run.call_args.args[0])
+
+    def test_uv_tool_runs_uv_tool_upgrade(self, version_checker: VersionChecker) -> None:
+        """A uv-tool install is upgraded with uv, not with the install script."""
+        with (
+            patch("budjira.utils.version.detect_install_method", return_value=InstallMethod.UV_TOOL),
+            patch("subprocess.run", return_value=self._ok_result()) as mock_run,
+        ):
+            success, _message = version_checker.perform_update()
+
+        assert success is True
+        assert mock_run.call_args.args[0] == ["uv", "tool", "upgrade", "budjira"]
+
+    def test_pipx_runs_pipx_upgrade(self, version_checker: VersionChecker) -> None:
+        """A pipx install is upgraded with pipx, not with the install script."""
+        with (
+            patch("budjira.utils.version.detect_install_method", return_value=InstallMethod.PIPX),
+            patch("subprocess.run", return_value=self._ok_result()) as mock_run,
+        ):
+            success, _message = version_checker.perform_update()
+
+        assert success is True
+        assert mock_run.call_args.args[0] == ["pipx", "upgrade", "budjira"]
+
+    def test_unknown_install_refuses_instead_of_shadow_install(self, version_checker: VersionChecker) -> None:
+        """An unrecognized install must not silently create a parallel git-clone install."""
+        with (
+            patch("budjira.utils.version.detect_install_method", return_value=InstallMethod.UNKNOWN),
+            patch("subprocess.run") as mock_run,
+        ):
+            success, message = version_checker.perform_update()
+
+        assert success is False
+        mock_run.assert_not_called()
+        assert "manual" in message.lower()


### PR DESCRIPTION
Closes #99.

## Problem

`perform_update()` always ran the git-clone install script, no matter how budjira
was installed. For a uv-tool or pipx install that creates a *second*, parallel
install under `~/.local/share/budjira` which can shadow the real binary depending
on `PATH` order — while the actually-installed package is never updated.

## What changed

`detect_install_method()` derives the install method from the location of the
running package, and `perform_update()` dispatches on it:

| Detected layout | Update action |
|-----------------|---------------|
| git checkout (a `.git` above the package) | `install.sh` from master (unchanged) |
| `.../uv/tools/...` | `uv tool upgrade budjira` |
| `.../pipx/venvs/...` | `pipx upgrade budjira` |
| anything else | refuses, points at a manual update |

The refusal is the point: guessing here is what produced the shadow install.

## Docs

The issue proposed either dispatching or correcting the docs. Both were needed —
budjira is **not on PyPI** (`https://pypi.org/pypi/budjira/json` → 404), so the
`uvx install budjira` / `pipx install budjira` / `pip install budjira` methods
CLAUDE.md advertised could never have worked. CLAUDE.md also claimed the version
check queries the PyPI JSON API; the code queries the GitHub Releases API.

- `CLAUDE.md`: install methods corrected (install script, or uv tool / pipx from
  the git URL), self-update section now describes the actual dispatch table.
- `README.md`: short note on which updater runs for which install.
- AI usage prompt regenerated — it also picked up pre-existing drift
  (`worklog delete`, worklog IDs) that had never been regenerated.

## Tests

8 new tests: 4 for detection (git clone / uv tool / pipx / unrecognized, each
against a real directory layout in `tmp_path`), 4 for dispatch — including that
an unrecognized install runs **no** subprocess at all.

912 passed, 3 skipped. Coverage 86.44% overall, 88% for `version.py`.