### PR TITLE
feat(issue): transition screen fields and validator attribution

### DIFF
--- a/.claude/ai-usage-prompt.md
+++ b/.claude/ai-usage-prompt.md
@@ -335,7 +335,13 @@ budjira create issue "Issue summary" --no-interactive [OPTIONS]
 - `--label TAG`: Add label (can be used multiple times)
 - `--project KEY`: Override default project
 - `--epic KEY`: Link to epic during creation
+- `--parent KEY`: Parent issue key for sub-tasks (required when the type is a sub-task)
 - `--custom NAME=VALUE`: Set custom field (repeatable, requires configuration)
+
+**Sub-tasks:** Use `--parent PROJ-123` to create a sub-task under a parent issue.
+The sub-task type name varies per instance (often `Subtask`, sometimes `Sub-task`);
+budjira detects sub-task types via cached project metadata (`budjira project show`)
+and fails fast with a clear message if a sub-task is created without `--parent`.
 
 **Examples:**
 
@@ -359,6 +365,12 @@ budjira create issue "Add export functionality" \
 # Quick task creation
 budjira create issue "Update documentation" \
   --type Task \
+  --no-interactive
+
+# Sub-task under a parent issue (Epic > Story > Sub-task workflows)
+budjira create issue "Implement login form" \
+  --type Subtask \
+  --parent PROJ-123 \
   --no-interactive
 
 # With custom fields (requires configuration in connections.toml)
@@ -452,6 +464,9 @@ Update existing issues with status transitions, field changes, and label managem
 - `--add-label TAG`: Add label (repeatable)
 - `--remove-label TAG`: Remove label (repeatable)
 - `--epic EPIC-KEY`, `-e`: Link issue to epic
+- `--field KEY=VALUE`: Transition screen field, by field id or display name (repeatable, requires `--status`)
+- `--dry-run`: Show the transition and its fields without performing it
+- `--interactive/--no-interactive`, `-i/-n`: Prompt for missing required fields (default: interactive)
 
 **Examples:**
 
@@ -482,6 +497,31 @@ budjira issue update PROJ-123 \
   --add-label backend \
   --add-label security
 ```
+
+### Transition Screen Fields
+
+Some transitions require fields that only exist on the transition screen. Without
+them the transition cannot be completed at all.
+
+```bash
+# See what a transition needs without performing it
+budjira issue update PROJ-123 --status "Resolve" --dry-run
+
+# Supply fields by id or by display name
+budjira issue update PROJ-123 --status "Resolve" \
+  --field resolution=Done \
+  --field "Solution details=Rolled out"
+```
+
+**Behaviour for automation:** non-interactive callers (agents, CI, piped stdin) never
+get a prompt. A missing required field aborts with a list of the required fields
+including id, type and allowed values, ready to paste back as `--field` arguments.
+
+**Workflow validators:** when a validator rejects the transition, Jira returns a
+message with an empty `errors` object that never names the field. budjira matches
+the message against the transition's screen fields and reports the field it means.
+If no single field matches, Jira's own message is forwarded unchanged — budjira does
+not guess.
 
 ### Delete Issue
 
@@ -1168,12 +1208,47 @@ budjira --format json sprint show
 - Sprint header with name, state, and dates
 - Table of issues with: Key, Type, Status, Priority, Summary, Assignee
 
+### Sprint Management (Write Operations)
+
+Move issues into sprints and manage the sprint lifecycle. Lifecycle and
+delete operations require Jira board-admin permissions; a 403 is reported as
+a permission error.
+
+```bash
+# Move one or more issues into a sprint (by name or ID)
+budjira sprint move ISSUE-KEY [ISSUE-KEY ...] --to "Sprint 42"
+budjira sprint move PROJ-1 PROJ-2 --sprint-id 100
+
+# Create a new (future) sprint; dates are optional
+budjira sprint create "Sprint 43"
+budjira sprint create "Sprint 43" --start today --end 2026-06-14 --goal "Ship the API"
+
+# Start a sprint (-> active); Jira requires start+end dates
+budjira sprint start "Sprint 43" --start today --end 2026-06-14
+budjira sprint start --sprint-id 100 --force
+
+# Close a sprint (-> closed); defaults to the active sprint
+budjira sprint close
+budjira sprint close "Sprint 42" --force
+```
+
+**Key points:**
+- `move` is additive and needs no confirmation. Target via `--to NAME` or `--sprint-id ID` (one is required).
+- `start`/`close` prompt for confirmation; use `--force`/`-f` to skip. In JSON mode `--force` is mandatory.
+- Sprint dates accept ISO (`2026-06-14`), `today`, `tomorrow`, or `yesterday`.
+- All commands support `--board`, `--connection`, and `--format json`.
+
 ### Board Configuration
 
 The board is resolved in this order:
 1. `--board` CLI flag (highest priority)
 2. `board_id` from connection config (set in connections.toml)
-3. Auto-detection from project (works when exactly one Scrum board exists)
+3. Auto-detection from project (works when exactly one sprint-capable board exists)
+
+Both company-managed (board type `scrum`) and team-managed (board type `simple`)
+projects are supported. For team-managed projects, passing `--sprint-id`
+directly to `sprint move/start/close` skips board detection entirely and
+operates on the sprint via the agile API.
 
 To configure a default board in `connections.toml`:
 ```toml
@@ -1237,7 +1312,9 @@ budjira update
 Interactive update process:
 1. Shows available version and release notes
 2. Asks for confirmation
-3. Runs installation script
+3. Runs the updater matching the install method (install script for a git
+   checkout, `uv tool upgrade` for uv tool, `pipx upgrade` for pipx; refuses
+   if the install method cannot be determined)
 4. Restarts with new version
 
 ### Force Update Check

--- a/.claude/context.md
+++ b/.claude/context.md
@@ -11,7 +11,7 @@
 ## Aktueller Stand
 
 ### Version & Release Status
-- **Current Version**: v1.22.0
+- **Current Version**: v1.22.1
 - **Branch**: master
 - **Status**: Local-first release workflow live (cz bump owns versioning)
 - **Last Update**: 2026-07-28
@@ -284,10 +284,10 @@ budjira/services/
 
 | Metrik | Wert |
 |--------|------|
-| **Total Tests** | 833 |
+| **Total Tests** | 962 |
 | **Skipped Tests** | 3 |
-| **Coverage** | 85.67% |
-| **Test Duration** | ~15s |
+| **Coverage** | 86.90% |
+| **Test Duration** | ~14s |
 
 ### Coverage by Module (Top)
 ```
@@ -440,13 +440,16 @@ budjira/
 | Issue Delete | v1.15.0 | `budjira issue delete` |
 | Workflow Profiles | v1.16.0 | `budjira workflow *` |
 | Sprint Querying | v1.17.0 | `budjira sprint list`, `sprint show` |
-| Sprint Management | pending | `budjira sprint move/create/start/close` |
-| Sub-task Creation | pending | `budjira create issue --type Subtask --parent KEY` |
+| Sprint Management | v1.21.0 | `budjira sprint move/create/start/close` |
+| Sub-task Creation | v1.21.0 | `budjira create issue --type Subtask --parent KEY` |
 | Workflow Sprint | v1.17.0 | `budjira workflow sprint` |
 | Booking Policy Enforcement | v1.17.0 | `budjira tempo log` (workflow) |
 | Cross-instance Tempo Fix | v1.18.1 | `budjira workflow book` |
 | Project Metadata | v1.19.0 | `budjira project sync/show/clear` |
 | Tempo issueId Fix | v1.19.1 | `budjira tempo worklogs` |
+| Worklog List JSON + Author | v1.22.0 | `budjira worklog list --format json --mine` |
+| Install-Method-Aware Update | v1.22.1 | `budjira update` |
+| Transition Screen Fields | pending | `budjira issue update --status X --field k=v --dry-run` |
 | Self-Update | v0.4.0 | `budjira update` |
 
 ---

--- a/README.md
+++ b/README.md
@@ -309,6 +309,28 @@ budjira issue delete PROJ-123 --force
 budjira issue delete PROJ-123 --delete-subtasks
 ```
 
+**Transition screen fields**
+
+Some transitions present a screen with fields that must be filled:
+
+```bash
+# Inspect what a transition needs, without touching the issue
+budjira issue update PROJ-123 --status "Resolve" --dry-run
+
+# Supply screen fields by id or by display name
+budjira issue update PROJ-123 --status "Resolve" \
+  --field resolution=Done \
+  --field "Solution details=Rolled out to production"
+```
+
+Missing required fields are prompted for interactively. With `--no-interactive`,
+or when stdin is not a terminal, budjira aborts and lists exactly which fields
+are needed instead of hanging on a prompt.
+
+Some fields are enforced by a workflow validator rather than by the screen. Jira
+reports those without naming the field; budjira matches the message against the
+transition's fields and tells you which one it means.
+
 ### 8. View Epic Progress
 
 ```bash

--- a/budjira/cli/issue.py
+++ b/budjira/cli/issue.py
@@ -1,15 +1,24 @@
 """CLI commands for updating Jira issues."""
 
-from typing import Annotated
+import sys
+from typing import Annotated, Any
 
 import typer
 from rich.console import Console
 from rich.table import Table
 
 from budjira.core.jira_client import JiraClient
+from budjira.models.transition import Transition
 from budjira.utils.connection import get_active_connection
 from budjira.utils.errors import BudjiraError, InvalidIssueError, PermissionError
 from budjira.utils.time_parser import parse_time_string
+from budjira.utils.transition_fields import (
+    attribute_validator_error,
+    format_field_requirements,
+    missing_required_fields,
+    parse_field_args,
+    resolve_fields,
+)
 
 app = typer.Typer(
     name="issue",
@@ -78,10 +87,80 @@ def delete_issue(
         raise typer.Exit(1) from e
 
 
+def _can_prompt() -> bool:
+    """Whether prompting can actually succeed.
+
+    budjira is frequently driven by agents and CI, where ``--no-interactive`` is
+    easy to forget. Without a terminal attached a prompt would hang forever, so
+    the absence of a TTY counts as non-interactive regardless of the flag.
+
+    Returns:
+        True if stdin is a terminal
+    """
+    return sys.stdin.isatty()
+
+
+def _collect_transition_fields(
+    client: JiraClient,
+    issue_key: str,
+    status: str,
+    field_args: list[str] | None,
+    interactive: bool,
+    dry_run: bool,
+) -> tuple[Transition, dict[str, Any]]:
+    """Resolve screen field values for a transition, prompting when allowed.
+
+    Args:
+        client: Connected Jira client
+        issue_key: Issue key
+        status: Transition name requested with --status
+        field_args: Raw --field arguments
+        interactive: Whether prompting is permitted
+        dry_run: Whether this is a dry run (never prompts)
+
+    Returns:
+        The matched transition and the resolved field values
+
+    Raises:
+        BudjiraError: If the transition is unknown or a required field is missing
+    """
+    transitions = client.transitions.get_transition_details(issue_key)
+    matched = next((t for t in transitions if t.name.lower() == status.lower()), None)
+    if matched is None:
+        available = ", ".join(t.name for t in transitions) or "none"
+        raise BudjiraError(f"Invalid transition '{status}' for {issue_key}. Available transitions: {available}")
+
+    resolved = resolve_fields(parse_field_args(field_args), matched)
+
+    missing = missing_required_fields(resolved, matched)
+    if missing and not dry_run:
+        if interactive and _can_prompt():
+            for field_meta in missing:
+                answer = typer.prompt(f"{field_meta.name} ({field_meta.field_id})")
+                resolved.update(resolve_fields({field_meta.field_id: answer}, matched))
+        else:
+            raise BudjiraError(
+                f"Transition '{matched.name}' requires field values that were not supplied:\n"
+                f"{format_field_requirements(missing)}"
+            )
+
+    return matched, resolved
+
+
 @app.command("update")
 def update_issue(
     issue_key: Annotated[str, typer.Argument(help="Issue key (e.g., PROJ-123)")],
     status: Annotated[str | None, typer.Option("--status", "-s", help="Transition to status")] = None,
+    field: Annotated[
+        list[str] | None,
+        typer.Option("--field", help="Transition screen field as key=value (repeatable)"),
+    ] = None,
+    dry_run: Annotated[
+        bool, typer.Option("--dry-run", help="Show the transition and its fields without performing it")
+    ] = False,
+    interactive: Annotated[
+        bool, typer.Option("--interactive/--no-interactive", "-i/-n", help="Prompt for missing required fields")
+    ] = True,
     assignee: Annotated[
         str | None, typer.Option("--assignee", "-a", help="Assign to user (username or 'currentUser()')")
     ] = None,
@@ -134,6 +213,7 @@ def update_issue(
         if not any(
             [
                 status,
+                field,
                 assignee is not None,
                 priority,
                 add_label,
@@ -159,10 +239,29 @@ def update_issue(
         # Track changes for output
         changes: list[tuple[str, str]] = []
 
+        # Screen fields have no meaning without a transition to resolve them against
+        if field and not status:
+            console.print("[red]Error:[/red] --field requires --status; screen fields belong to a transition.")
+            raise typer.Exit(1)
+
         # Perform status transition first (if specified)
         if status:
             try:
-                client.transition_issue(issue_key, status)
+                matched, resolved = _collect_transition_fields(client, issue_key, status, field, interactive, dry_run)
+
+                if dry_run:
+                    console.print(f"[cyan]Dry run:[/cyan] would transition {issue_key} via '{matched.name}'")
+                    if matched.to_status:
+                        console.print(f"  Target status: {matched.to_status}")
+                    for field_id, value in resolved.items():
+                        console.print(f"  {field_id} = {value}")
+                    still_missing = missing_required_fields(resolved, matched)
+                    if still_missing:
+                        console.print("[yellow]Missing required fields:[/yellow]")
+                        console.print(format_field_requirements(still_missing))
+                    return
+
+                client.transitions.transition(issue_key, matched.name, fields=resolved or None)
                 changes.append(("Status", f"→ {status}"))
             except BudjiraError as e:
                 console.print(f"[red]✗[/red] Status update failed: {e}")

--- a/budjira/cli/issue.py
+++ b/budjira/cli/issue.py
@@ -87,6 +87,36 @@ def delete_issue(
         raise typer.Exit(1) from e
 
 
+def _validator_messages(error: Exception) -> list[str]:
+    """Extract errorMessages from a Jira error whose 'errors' object is empty.
+
+    A populated 'errors' object means Jira already named the field, so there is
+    nothing to attribute.
+
+    Args:
+        error: Exception raised while transitioning
+
+    Returns:
+        The anonymous validator messages, empty if this is not that case
+    """
+    # The service layer converts JIRAError into JiraAPIError and keeps only the
+    # error text, so the response body survives solely in the __cause__ chain.
+    # Walk it, otherwise attribution never fires outside of unit tests.
+    current: BaseException | None = error
+    while current is not None:
+        response = getattr(current, "response", None)
+        if response is not None:
+            try:
+                body = response.json()
+            except Exception:
+                # A non-JSON body simply carries no attribution.
+                body = None
+            if isinstance(body, dict) and not body.get("errors"):
+                return [str(m) for m in body.get("errorMessages") or []]
+        current = current.__cause__
+    return []
+
+
 def _can_prompt() -> bool:
     """Whether prompting can actually succeed.
 
@@ -261,7 +291,36 @@ def update_issue(
                         console.print(format_field_requirements(still_missing))
                     return
 
-                client.transitions.transition(issue_key, matched.name, fields=resolved or None)
+                try:
+                    client.transitions.transition(issue_key, matched.name, fields=resolved or None)
+                except Exception as transition_error:
+                    messages = _validator_messages(transition_error)
+                    culprit = attribute_validator_error(messages, matched) if messages else None
+                    if culprit is None:
+                        if not messages:
+                            raise
+                        # Forward Jira's own wording rather than naming a field we
+                        # could not identify, but show what the screen offers.
+                        console.print(f"[red]✗[/red] Transition '{matched.name}' was rejected: {' '.join(messages)}")
+                        if matched.fields:
+                            console.print("Screen fields on this transition:")
+                            console.print(format_field_requirements(matched.fields))
+                        raise typer.Exit(1) from transition_error
+
+                    detail = f"'{culprit.name}' ({culprit.field_id})"
+                    if not (interactive and _can_prompt()):
+                        console.print(
+                            f"[red]✗[/red] Transition '{matched.name}' was rejected by a workflow validator. "
+                            f"The message refers to field {detail}. Supply it with:\n"
+                            f"{format_field_requirements([culprit])}"
+                        )
+                        raise typer.Exit(1) from transition_error
+
+                    console.print(f"[yellow]![/yellow] A workflow validator requires field {detail}.")
+                    answer = typer.prompt(f"{culprit.name} ({culprit.field_id})")
+                    resolved.update(resolve_fields({culprit.field_id: answer}, matched))
+                    client.transitions.transition(issue_key, matched.name, fields=resolved)
+
                 changes.append(("Status", f"→ {status}"))
             except BudjiraError as e:
                 console.print(f"[red]✗[/red] Status update failed: {e}")
@@ -342,8 +401,8 @@ def update_issue(
             table.add_column("Field", style="cyan")
             table.add_column("Change", style="")
 
-            for field, change in changes:
-                table.add_row(field, change)
+            for field_name, change in changes:
+                table.add_row(field_name, change)
 
             console.print(table)
 

--- a/budjira/models/__init__.py
+++ b/budjira/models/__init__.py
@@ -2,6 +2,7 @@
 
 from budjira.models.config import GlobalConfig, LogLevel, OutputFormat
 from budjira.models.connection import Connection, ConnectionList
+from budjira.models.transition import Transition, TransitionField
 
 __all__ = [
     "Connection",
@@ -9,4 +10,6 @@ __all__ = [
     "GlobalConfig",
     "LogLevel",
     "OutputFormat",
+    "Transition",
+    "TransitionField",
 ]

--- a/budjira/models/ai_prompt.py
+++ b/budjira/models/ai_prompt.py
@@ -602,6 +602,9 @@ Update existing issues with status transitions, field changes, and label managem
 - `--add-label TAG`: Add label (repeatable)
 - `--remove-label TAG`: Remove label (repeatable)
 - `--epic EPIC-KEY`, `-e`: Link issue to epic
+- `--field KEY=VALUE`: Transition screen field, by field id or display name (repeatable, requires `--status`)
+- `--dry-run`: Show the transition and its fields without performing it
+- `--interactive/--no-interactive`, `-i/-n`: Prompt for missing required fields (default: interactive)
 
 **Examples:**
 
@@ -632,6 +635,31 @@ budjira issue update PROJ-123 \\
   --add-label backend \\
   --add-label security
 ```
+
+### Transition Screen Fields
+
+Some transitions require fields that only exist on the transition screen. Without
+them the transition cannot be completed at all.
+
+```bash
+# See what a transition needs without performing it
+budjira issue update PROJ-123 --status "Resolve" --dry-run
+
+# Supply fields by id or by display name
+budjira issue update PROJ-123 --status "Resolve" \\
+  --field resolution=Done \\
+  --field "Solution details=Rolled out"
+```
+
+**Behaviour for automation:** non-interactive callers (agents, CI, piped stdin) never
+get a prompt. A missing required field aborts with a list of the required fields
+including id, type and allowed values, ready to paste back as `--field` arguments.
+
+**Workflow validators:** when a validator rejects the transition, Jira returns a
+message with an empty `errors` object that never names the field. budjira matches
+the message against the transition's screen fields and reports the field it means.
+If no single field matches, Jira's own message is forwarded unchanged — budjira does
+not guess.
 
 ### Delete Issue
 

--- a/budjira/models/transition.py
+++ b/budjira/models/transition.py
@@ -1,0 +1,24 @@
+"""Data models for Jira workflow transitions and their screen fields."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class TransitionField(BaseModel):
+    """A single field on a transition screen."""
+
+    field_id: str = Field(..., description="Jira field id (e.g., 'customfield_10001')")
+    name: str = Field(..., description="Display name shown on the transition screen")
+    required: bool = Field(..., description="Whether Jira marks the field as required")
+    field_type: str | None = Field(None, description="Field schema type (e.g., 'string', 'option', 'array')")
+    allowed_values: list[str] | None = Field(None, description="Permitted values, if the field is constrained")
+
+
+class Transition(BaseModel):
+    """A workflow transition available from an issue's current status."""
+
+    id: str = Field(..., description="Transition id used when executing the transition")
+    name: str = Field(..., description="Transition name (e.g., 'Start Progress')")
+    to_status: str | None = Field(None, description="Status the issue reaches through this transition")
+    fields: list[TransitionField] = Field(default_factory=list, description="Fields on the transition screen")

--- a/budjira/models/transition.py
+++ b/budjira/models/transition.py
@@ -11,8 +11,8 @@ class TransitionField(BaseModel):
     field_id: str = Field(..., description="Jira field id (e.g., 'customfield_10001')")
     name: str = Field(..., description="Display name shown on the transition screen")
     required: bool = Field(..., description="Whether Jira marks the field as required")
-    field_type: str | None = Field(None, description="Field schema type (e.g., 'string', 'option', 'array')")
-    allowed_values: list[str] | None = Field(None, description="Permitted values, if the field is constrained")
+    field_type: str | None = Field(default=None, description="Field schema type (e.g., 'string', 'option', 'array')")
+    allowed_values: list[str] | None = Field(default=None, description="Permitted values, if the field is constrained")
 
 
 class Transition(BaseModel):
@@ -20,5 +20,5 @@ class Transition(BaseModel):
 
     id: str = Field(..., description="Transition id used when executing the transition")
     name: str = Field(..., description="Transition name (e.g., 'Start Progress')")
-    to_status: str | None = Field(None, description="Status the issue reaches through this transition")
+    to_status: str | None = Field(default=None, description="Status the issue reaches through this transition")
     fields: list[TransitionField] = Field(default_factory=list, description="Fields on the transition screen")

--- a/budjira/services/transitions.py
+++ b/budjira/services/transitions.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from jira.exceptions import JIRAError
 
+from budjira.models.transition import Transition, TransitionField
 from budjira.services.base import BaseJiraService
 from budjira.utils.errors import InvalidIssueError, JiraAPIError
 
@@ -38,6 +41,62 @@ class TransitionService(BaseJiraService):
             raise
         except Exception as e:
             raise JiraAPIError(f"Unexpected error fetching transitions: {e}") from e
+
+    def get_transition_details(self, issue_key: str) -> list[Transition]:
+        """Get available transitions including their screen fields.
+
+        Args:
+            issue_key: Issue key (e.g., PROJ-123)
+
+        Returns:
+            List of transitions with typed screen field metadata
+
+        Raises:
+            InvalidIssueError: If issue not found
+            JiraAPIError: If retrieval fails
+        """
+        try:
+            self._log_operation("Fetch transition details", issue_key=issue_key)
+            raw_transitions = self.client.transitions(issue_key, expand="transitions.fields")
+            return [self._parse_transition(raw) for raw in raw_transitions]
+        except JIRAError as e:
+            if e.status_code == 404:
+                raise InvalidIssueError(f"Issue '{issue_key}' not found") from e
+            self._handle_jira_error(e, "Fetch transition details", issue_key=issue_key)
+            raise  # Ensure type checker knows this path raises
+        except (InvalidIssueError, JiraAPIError):
+            raise
+        except Exception as e:
+            raise JiraAPIError(f"Unexpected error fetching transition details: {e}") from e
+
+    @staticmethod
+    def _parse_transition(raw: dict[str, Any]) -> Transition:
+        """Map one raw Jira transition dict into a Transition model."""
+        fields = [
+            TransitionField(
+                field_id=field_id,
+                name=meta.get("name", field_id),
+                required=bool(meta.get("required", False)),
+                field_type=(meta.get("schema") or {}).get("type"),
+                allowed_values=TransitionService._parse_allowed_values(meta),
+            )
+            for field_id, meta in (raw.get("fields") or {}).items()
+        ]
+        return Transition(
+            id=str(raw["id"]),
+            name=raw["name"],
+            to_status=(raw.get("to") or {}).get("name"),
+            fields=fields,
+        )
+
+    @staticmethod
+    def _parse_allowed_values(meta: dict[str, Any]) -> list[str] | None:
+        """Extract allowed values; entries carry 'name' or 'value' depending on field type."""
+        raw_values = meta.get("allowedValues")
+        if not raw_values:
+            return None
+        values = [v.get("name") or v.get("value") for v in raw_values if isinstance(v, dict)]
+        return [v for v in values if v] or None
 
     def transition(self, issue_key: str, transition_name: str) -> None:
         """Transition an issue to a new status.

--- a/budjira/services/transitions.py
+++ b/budjira/services/transitions.py
@@ -98,12 +98,13 @@ class TransitionService(BaseJiraService):
         values = [v.get("name") or v.get("value") for v in raw_values if isinstance(v, dict)]
         return [v for v in values if v] or None
 
-    def transition(self, issue_key: str, transition_name: str) -> None:
+    def transition(self, issue_key: str, transition_name: str, fields: dict[str, Any] | None = None) -> None:
         """Transition an issue to a new status.
 
         Args:
             issue_key: Issue key (e.g., PROJ-123)
             transition_name: Name of the transition (e.g., "In Progress", "Done")
+            fields: Optional transition screen field values, keyed by Jira field id
 
         Raises:
             InvalidIssueError: If issue not found
@@ -128,7 +129,7 @@ class TransitionService(BaseJiraService):
                     f"Invalid transition '{transition_name}' for {issue_key}. Available transitions: {available}"
                 )
 
-            self.client.transition_issue(issue_key, transition_id)
+            self.client.transition_issue(issue_key, transition_id, fields=fields)
             self._logger.info(f"Successfully transitioned {issue_key} to '{transition_name}'")
 
         except JIRAError as e:

--- a/budjira/utils/transition_fields.py
+++ b/budjira/utils/transition_fields.py
@@ -1,0 +1,161 @@
+"""Parsing, resolution and encoding of transition screen field values.
+
+These helpers are pure functions over transition metadata: no Jira client, no I/O.
+The CLI composes them, which keeps the fiddly matching logic testable on its own.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from budjira.utils.errors import ValidationError
+
+if TYPE_CHECKING:
+    from budjira.models.transition import Transition, TransitionField
+
+# Field schema types that Jira expects wrapped rather than as a plain string.
+_NAME_WRAPPED_TYPES = {"resolution", "priority"}
+_VALUE_WRAPPED_TYPES = {"option"}
+_ARRAY_TYPES = {"array"}
+
+
+def parse_field_args(field_args: list[str] | None) -> dict[str, str]:
+    """Parse repeatable --field key=value arguments.
+
+    Args:
+        field_args: Raw strings from the CLI, or None
+
+    Returns:
+        Mapping of user-supplied key to raw string value
+
+    Raises:
+        ValidationError: If an argument is not in key=value form
+    """
+    parsed: dict[str, str] = {}
+    for arg in field_args or []:
+        key, separator, value = arg.partition("=")
+        if not separator or not key.strip():
+            raise ValidationError(
+                f"Invalid field argument '{arg}'. Expected format: key=value (e.g., --field resolution=Done)."
+            )
+        parsed[key.strip()] = value
+    return parsed
+
+
+def encode_field_value(field: TransitionField, value: str) -> Any:
+    """Encode a raw string into the shape Jira expects for this field type.
+
+    Structured fields reject a plain string: a select field needs {"value": ...},
+    a multi-select a list of those, and resolution/priority accept {"name": ...}.
+    Types beyond these are deliberately passed through untouched, so an
+    unsupported one surfaces as a Jira error instead of being silently mangled.
+
+    Args:
+        field: The screen field the value belongs to
+        value: Raw string from the CLI or a prompt
+
+    Returns:
+        The value in Jira's expected representation
+    """
+    field_type = (field.field_type or "").lower()
+    if field_type in _ARRAY_TYPES:
+        return [{"value": value}]
+    if field_type in _VALUE_WRAPPED_TYPES:
+        return {"value": value}
+    if field_type in _NAME_WRAPPED_TYPES:
+        return {"name": value}
+    return value
+
+
+def resolve_fields(raw_fields: dict[str, str], transition: Transition) -> dict[str, Any]:
+    """Resolve user-supplied keys against a transition's screen fields.
+
+    A key matches either a field id exactly or a display name case-insensitively.
+
+    Args:
+        raw_fields: Mapping of user-supplied key to raw string value
+        transition: The transition whose screen defines the valid fields
+
+    Returns:
+        Mapping of Jira field id to encoded value
+
+    Raises:
+        ValidationError: If a key is unknown or ambiguous, or a value is not allowed
+    """
+    resolved: dict[str, Any] = {}
+    for key, value in raw_fields.items():
+        field = _match_field(key, transition)
+        if field.allowed_values and value not in field.allowed_values:
+            allowed = ", ".join(field.allowed_values)
+            raise ValidationError(
+                f"Value '{value}' is not allowed for field '{field.name}' ({field.field_id}). "
+                f"Allowed values: {allowed}"
+            )
+        resolved[field.field_id] = encode_field_value(field, value)
+    return resolved
+
+
+def _match_field(key: str, transition: Transition) -> TransitionField:
+    """Find the single screen field a user-supplied key refers to.
+
+    Args:
+        key: Field id or display name as typed by the user
+        transition: The transition whose screen is being matched against
+
+    Returns:
+        The matching field
+
+    Raises:
+        ValidationError: If the key matches no field or several
+    """
+    for field in transition.fields:
+        if field.field_id == key:
+            return field
+
+    matches = [f for f in transition.fields if f.name.lower() == key.lower()]
+    if len(matches) == 1:
+        return matches[0]
+    if len(matches) > 1:
+        candidates = ", ".join(f.field_id for f in matches)
+        raise ValidationError(
+            f"Field name '{key}' is ambiguous on transition '{transition.name}'. "
+            f"Use the field id instead: {candidates}"
+        )
+
+    available = ", ".join(f"{f.field_id} ('{f.name}')" for f in transition.fields) or "none"
+    raise ValidationError(
+        f"Unknown field '{key}' for transition '{transition.name}'. Available screen fields: {available}"
+    )
+
+
+def missing_required_fields(resolved: dict[str, Any], transition: Transition) -> list[TransitionField]:
+    """List required screen fields that have no value yet.
+
+    Args:
+        resolved: Already-resolved values, keyed by Jira field id
+        transition: The transition whose screen defines the required fields
+
+    Returns:
+        Required fields still missing a value
+    """
+    return [f for f in transition.fields if f.required and f.field_id not in resolved]
+
+
+def format_field_requirements(fields: list[TransitionField]) -> str:
+    """Render fields as copy-pasteable --field hints.
+
+    Args:
+        fields: Fields to describe
+
+    Returns:
+        One line per field, ready to paste back as CLI arguments
+    """
+    lines = []
+    for field in fields:
+        parts = [f"  --field {field.field_id}=<value>", f"# {field.name}"]
+        if field.field_type:
+            parts.append(f"[{field.field_type}]")
+        if field.allowed_values:
+            parts.append(f"one of: {', '.join(field.allowed_values)}")
+        lines.append(" ".join(parts))
+    return "\n".join(lines)

--- a/budjira/utils/transition_fields.py
+++ b/budjira/utils/transition_fields.py
@@ -6,6 +6,7 @@ The CLI composes them, which keeps the fiddly matching logic testable on its own
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING, Any
 
 from budjira.utils.errors import ValidationError
@@ -17,6 +18,10 @@ if TYPE_CHECKING:
 _NAME_WRAPPED_TYPES = {"resolution", "priority"}
 _VALUE_WRAPPED_TYPES = {"option"}
 _ARRAY_TYPES = {"array"}
+
+# Words shorter than this carry no signal when matching a validator message
+# against a field name ("QA", "of", "id").
+_MIN_TOKEN_LENGTH = 3
 
 
 def parse_field_args(field_args: list[str] | None) -> dict[str, str]:
@@ -139,6 +144,49 @@ def missing_required_fields(resolved: dict[str, Any], transition: Transition) ->
         Required fields still missing a value
     """
     return [f for f in transition.fields if f.required and f.field_id not in resolved]
+
+
+def _words(text: str) -> set[str]:
+    """Split text into lowercase words, dropping ones too short to carry signal."""
+    return {w for w in re.findall(r"\w+", text.lower()) if len(w) >= _MIN_TOKEN_LENGTH}
+
+
+def attribute_validator_error(messages: list[str], transition: Transition) -> TransitionField | None:
+    """Find the screen field a workflow validator message refers to.
+
+    Workflow validators report failures with an empty ``errors`` object, so the
+    offending field is never named. Jira's wording rarely quotes the field name
+    verbatim either — a field called "Solution details" is reported as "Provide
+    details about the solution made available." Matching therefore requires every
+    significant word of the field name to appear in the message, in any order.
+
+    A field is only returned when it is the single best match. Two equally good
+    candidates yield None, so the caller forwards Jira's own message rather than
+    naming the wrong field.
+
+    Args:
+        messages: Jira's errorMessages entries
+        transition: The transition that was attempted
+
+    Returns:
+        The matched field, or None when nothing matches unambiguously
+    """
+    best: list[TransitionField] = []
+    best_score = 0
+
+    for message in messages:
+        message_words = _words(message)
+        for field in transition.fields:
+            field_words = _words(field.name)
+            if not field_words or not field_words <= message_words:
+                continue
+            score = len(field_words)
+            if score > best_score:
+                best, best_score = [field], score
+            elif score == best_score:
+                best.append(field)
+
+    return best[0] if len(best) == 1 else None
 
 
 def format_field_requirements(fields: list[TransitionField]) -> str:

--- a/budjira/utils/transition_fields.py
+++ b/budjira/utils/transition_fields.py
@@ -93,8 +93,7 @@ def resolve_fields(raw_fields: dict[str, str], transition: Transition) -> dict[s
         if field.allowed_values and value not in field.allowed_values:
             allowed = ", ".join(field.allowed_values)
             raise ValidationError(
-                f"Value '{value}' is not allowed for field '{field.name}' ({field.field_id}). "
-                f"Allowed values: {allowed}"
+                f"Value '{value}' is not allowed for field '{field.name}' ({field.field_id}). Allowed values: {allowed}"
             )
         resolved[field.field_id] = encode_field_value(field, value)
     return resolved
@@ -123,8 +122,7 @@ def _match_field(key: str, transition: Transition) -> TransitionField:
     if len(matches) > 1:
         candidates = ", ".join(f.field_id for f in matches)
         raise ValidationError(
-            f"Field name '{key}' is ambiguous on transition '{transition.name}'. "
-            f"Use the field id instead: {candidates}"
+            f"Field name '{key}' is ambiguous on transition '{transition.name}'. Use the field id instead: {candidates}"
         )
 
     available = ", ".join(f"{f.field_id} ('{f.name}')" for f in transition.fields) or "none"

--- a/tests/cli/test_issue.py
+++ b/tests/cli/test_issue.py
@@ -464,3 +464,118 @@ def test_missing_required_field_is_prompted_when_interactive(mock_client: MagicM
     mock_client.transitions.transition.assert_called_once_with(
         "TEST-123", "Resolve", fields={"customfield_10001": "Rolled out"}
     )
+
+
+def _validator_error() -> JIRAError:
+    """A workflow validator rejection: message set, errors object empty."""
+    error = JIRAError(status_code=400, text="Provide details about the solution made available.")
+    error.response = MagicMock()
+    error.response.json.return_value = {
+        "errorMessages": ["Provide details about the solution made available."],
+        "errors": {},
+    }
+    return error
+
+
+def test_validator_failure_names_the_field(mock_client: MagicMock) -> None:
+    """Jira's anonymous message is replaced by a concrete field name."""
+    mock_client.transitions.get_transition_details.return_value = [_transition_with_required_field()]
+    mock_client.transitions.transition.side_effect = _validator_error()
+
+    result = runner.invoke(
+        app,
+        [
+            "-q",
+            "issue",
+            "update",
+            "TEST-123",
+            "--status",
+            "Resolve",
+            "--field",
+            "customfield_10001=x",
+            "--no-interactive",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "customfield_10001" in result.stdout
+    assert "Solution details" in result.stdout
+
+
+def test_validator_failure_retries_once_when_interactive(mock_client: MagicMock) -> None:
+    """After prompting, retry exactly once."""
+    mock_client.transitions.get_transition_details.return_value = [_transition_with_required_field()]
+    mock_client.transitions.transition.side_effect = [_validator_error(), None]
+
+    with (
+        patch("budjira.cli.issue._can_prompt", return_value=True),
+        patch("typer.prompt", return_value="Rolled out"),
+    ):
+        result = runner.invoke(
+            app, ["-q", "issue", "update", "TEST-123", "--status", "Resolve", "--field", "customfield_10001=x"]
+        )
+
+    assert result.exit_code == 0
+    assert mock_client.transitions.transition.call_count == 2
+
+
+def test_unattributable_validator_message_is_forwarded(mock_client: MagicMock) -> None:
+    """Never invent a field name."""
+    error = JIRAError(status_code=400, text="Something else went wrong")
+    error.response = MagicMock()
+    error.response.json.return_value = {"errorMessages": ["Something else went wrong"], "errors": {}}
+    mock_client.transitions.get_transition_details.return_value = [_transition_with_required_field()]
+    mock_client.transitions.transition.side_effect = error
+
+    result = runner.invoke(
+        app,
+        [
+            "-q",
+            "issue",
+            "update",
+            "TEST-123",
+            "--status",
+            "Resolve",
+            "--field",
+            "customfield_10001=x",
+            "--no-interactive",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Something else went wrong" in result.stdout
+
+
+def test_validator_failure_is_attributed_through_the_service_error_wrapper(mock_client: MagicMock) -> None:
+    """Production shape: the service wraps JIRAError in JiraAPIError.
+
+    _handle_jira_error keeps only the error text, so the response body survives
+    solely in the __cause__ chain. Attribution must still work.
+    """
+    from budjira.utils.errors import JiraAPIError
+
+    original = _validator_error()
+    wrapped = JiraAPIError("Transition issue failed: Provide details about the solution made available.")
+    wrapped.__cause__ = original
+
+    mock_client.transitions.get_transition_details.return_value = [_transition_with_required_field()]
+    mock_client.transitions.transition.side_effect = wrapped
+
+    result = runner.invoke(
+        app,
+        [
+            "-q",
+            "issue",
+            "update",
+            "TEST-123",
+            "--status",
+            "Resolve",
+            "--field",
+            "customfield_10001=x",
+            "--no-interactive",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "customfield_10001" in result.stdout
+    assert "Solution details" in result.stdout

--- a/tests/cli/test_issue.py
+++ b/tests/cli/test_issue.py
@@ -2,9 +2,12 @@
 
 from unittest.mock import MagicMock, patch
 
+import pytest
 from budjira.cli.main import app
+from budjira.models.transition import Transition, TransitionField
 from budjira.utils.errors import InvalidIssueError
 from budjira.utils.errors import PermissionError as BudjiraPermissionError
+from jira.exceptions import JIRAError
 from typer.testing import CliRunner
 
 runner = CliRunner()
@@ -344,3 +347,120 @@ class TestIssueDelete:
 
         assert result.exit_code == 1
         assert "Permission denied" in result.stdout
+
+
+@pytest.fixture
+def mock_client():
+    """Patched JiraClient for transition tests (same patching the decorated tests do)."""
+    with (
+        patch("budjira.cli.issue.JiraClient") as mock_jira_cls,
+        patch("budjira.cli.issue.get_active_connection", return_value=_mock_connection()),
+    ):
+        client = MagicMock()
+        mock_jira_cls.from_connection.return_value = client
+        yield client
+
+
+def _transition_with_required_field() -> Transition:
+    """A transition whose screen carries one required text field."""
+    return Transition(
+        id="21",
+        name="Resolve",
+        to_status="Resolved",
+        fields=[
+            TransitionField(
+                field_id="customfield_10001",
+                name="Solution details",
+                required=True,
+                field_type="string",
+            )
+        ],
+    )
+
+
+def test_field_without_status_is_a_usage_error(mock_client: MagicMock) -> None:
+    """Screen fields only exist in the context of a transition."""
+    result = runner.invoke(app, ["-q", "issue", "update", "TEST-123", "--field", "resolution=Done"])
+
+    assert result.exit_code == 1
+    assert "--status" in result.stdout
+    mock_client.transitions.transition.assert_not_called()
+
+
+def test_missing_required_field_non_interactive_lists_requirements(mock_client: MagicMock) -> None:
+    """Without a TTY there is no prompt - abort with what is needed."""
+    mock_client.transitions.get_transition_details.return_value = [_transition_with_required_field()]
+
+    result = runner.invoke(app, ["-q", "issue", "update", "TEST-123", "--status", "Resolve", "--no-interactive"])
+
+    assert result.exit_code == 1
+    assert "customfield_10001" in result.stdout
+    assert "Solution details" in result.stdout
+    mock_client.transitions.transition.assert_not_called()
+
+
+def test_supplied_field_is_passed_to_the_transition(mock_client: MagicMock) -> None:
+    """A supplied screen field reaches the service layer."""
+    mock_client.transitions.get_transition_details.return_value = [_transition_with_required_field()]
+
+    result = runner.invoke(
+        app,
+        [
+            "-q",
+            "issue",
+            "update",
+            "TEST-123",
+            "--status",
+            "Resolve",
+            "--field",
+            "customfield_10001=Rolled out",
+            "--no-interactive",
+        ],
+    )
+
+    assert result.exit_code == 0
+    mock_client.transitions.transition.assert_called_once_with(
+        "TEST-123", "Resolve", fields={"customfield_10001": "Rolled out"}
+    )
+
+
+def test_dry_run_performs_no_transition(mock_client: MagicMock) -> None:
+    """A dry run must never touch the issue."""
+    mock_client.transitions.get_transition_details.return_value = [_transition_with_required_field()]
+
+    result = runner.invoke(
+        app,
+        ["-q", "issue", "update", "TEST-123", "--status", "Resolve", "--field", "customfield_10001=x", "--dry-run"],
+    )
+
+    assert result.exit_code == 0
+    assert "Resolve" in result.stdout
+    mock_client.transitions.transition.assert_not_called()
+
+
+def test_dry_run_does_not_prompt_for_missing_fields(mock_client: MagicMock) -> None:
+    """A dry run must not ask for values it will never send."""
+    mock_client.transitions.get_transition_details.return_value = [_transition_with_required_field()]
+
+    with patch("typer.prompt") as mock_prompt:
+        result = runner.invoke(app, ["-q", "issue", "update", "TEST-123", "--status", "Resolve", "--dry-run"])
+
+    assert result.exit_code == 0
+    mock_prompt.assert_not_called()
+    mock_client.transitions.transition.assert_not_called()
+
+
+def test_missing_required_field_is_prompted_when_interactive(mock_client: MagicMock) -> None:
+    """With a TTY the missing value is asked for instead of aborting."""
+    mock_client.transitions.get_transition_details.return_value = [_transition_with_required_field()]
+
+    with (
+        patch("budjira.cli.issue._can_prompt", return_value=True),
+        patch("typer.prompt", return_value="Rolled out"),
+    ):
+        result = runner.invoke(app, ["-q", "issue", "update", "TEST-123", "--status", "Resolve"])
+
+    assert result.exit_code == 0
+    mock_client.transitions.transition.assert_called_once_with(
+        "TEST-123", "Resolve", fields={"customfield_10001": "Rolled out"}
+    )

--- a/tests/core/test_jira_client.py
+++ b/tests/core/test_jira_client.py
@@ -656,7 +656,7 @@ class TestJiraClientTransitions:
         client = JiraClient(connection, "test-token")
         client.transition_issue("TEST-123", "In Progress")
 
-        mock_jira_instance.transition_issue.assert_called_once_with("TEST-123", "21")
+        mock_jira_instance.transition_issue.assert_called_once_with("TEST-123", "21", fields=None)
 
     @patch("budjira.core.jira_client.JIRA")
     def test_transition_issue_case_insensitive(self, mock_jira_class: Mock, connection: Connection) -> None:
@@ -670,7 +670,7 @@ class TestJiraClientTransitions:
         client = JiraClient(connection, "test-token")
         client.transition_issue("TEST-123", "in progress")  # lowercase
 
-        mock_jira_instance.transition_issue.assert_called_once_with("TEST-123", "21")
+        mock_jira_instance.transition_issue.assert_called_once_with("TEST-123", "21", fields=None)
 
     @patch("budjira.core.jira_client.JIRA")
     def test_transition_issue_invalid_transition(self, mock_jira_class: Mock, connection: Connection) -> None:

--- a/tests/models/test_transition.py
+++ b/tests/models/test_transition.py
@@ -33,7 +33,9 @@ class TestTransitionField:
 
     def test_missing_required_attribute_is_rejected(self) -> None:
         with pytest.raises(ValidationError):
-            TransitionField(field_id="customfield_10001", name="Solution details")
+            # The ignore below is deliberate: omitting 'required' is exactly what
+            # this test exercises, and mypy flags the call it is meant to make.
+            TransitionField(field_id="customfield_10001", name="Solution details")  # type: ignore[call-arg]
 
 
 class TestTransition:

--- a/tests/models/test_transition.py
+++ b/tests/models/test_transition.py
@@ -1,0 +1,59 @@
+"""Tests for transition models."""
+
+from __future__ import annotations
+
+import pytest
+from budjira.models.transition import Transition, TransitionField
+from pydantic import ValidationError
+
+
+class TestTransitionField:
+    """Test TransitionField model."""
+
+    def test_minimal_field(self) -> None:
+        field = TransitionField(field_id="customfield_10001", name="Solution details", required=True)
+
+        assert field.field_id == "customfield_10001"
+        assert field.name == "Solution details"
+        assert field.required is True
+        assert field.field_type is None
+        assert field.allowed_values is None
+
+    def test_field_with_allowed_values(self) -> None:
+        field = TransitionField(
+            field_id="resolution",
+            name="Resolution",
+            required=True,
+            field_type="resolution",
+            allowed_values=["Done", "Won't Do"],
+        )
+
+        assert field.field_type == "resolution"
+        assert field.allowed_values == ["Done", "Won't Do"]
+
+    def test_missing_required_attribute_is_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            TransitionField(field_id="customfield_10001", name="Solution details")
+
+
+class TestTransition:
+    """Test Transition model."""
+
+    def test_transition_without_fields(self) -> None:
+        transition = Transition(id="11", name="Start Progress")
+
+        assert transition.id == "11"
+        assert transition.to_status is None
+        assert transition.fields == []
+
+    def test_transition_with_fields(self) -> None:
+        transition = Transition(
+            id="21",
+            name="Resolve",
+            to_status="Resolved",
+            fields=[TransitionField(field_id="resolution", name="Resolution", required=True)],
+        )
+
+        assert transition.to_status == "Resolved"
+        assert len(transition.fields) == 1
+        assert transition.fields[0].field_id == "resolution"

--- a/tests/services/test_transitions.py
+++ b/tests/services/test_transitions.py
@@ -101,3 +101,41 @@ def test_get_transition_details_handles_transition_without_screen(mock_jira: Mag
 
     assert transitions[0].fields == []
     assert transitions[0].to_status is None
+
+
+def test_get_transition_details_maps_404_to_invalid_issue(mock_jira: MagicMock) -> None:
+    """A missing issue is reported as an issue problem, not a generic API error."""
+    from budjira.services.transitions import TransitionService
+    from budjira.utils.errors import InvalidIssueError
+    from jira.exceptions import JIRAError
+
+    mock_jira.transitions.side_effect = JIRAError(status_code=404, text="Not Found")
+    service = TransitionService(mock_jira)
+
+    with pytest.raises(InvalidIssueError, match="not found"):
+        service.get_transition_details("PROJ-999")
+
+
+def test_get_transition_details_maps_403_to_permission_error(mock_jira: MagicMock) -> None:
+    """A permission problem keeps its own exception type."""
+    from budjira.services.transitions import TransitionService
+    from budjira.utils.errors import PermissionError as BudjiraPermissionError
+    from jira.exceptions import JIRAError
+
+    mock_jira.transitions.side_effect = JIRAError(status_code=403, text="Forbidden")
+    service = TransitionService(mock_jira)
+
+    with pytest.raises(BudjiraPermissionError):
+        service.get_transition_details("PROJ-123")
+
+
+def test_get_transition_details_wraps_unexpected_errors(mock_jira: MagicMock) -> None:
+    """Anything else surfaces as a JiraAPIError rather than leaking out raw."""
+    from budjira.services.transitions import TransitionService
+    from budjira.utils.errors import JiraAPIError
+
+    mock_jira.transitions.side_effect = RuntimeError("socket exploded")
+    service = TransitionService(mock_jira)
+
+    with pytest.raises(JiraAPIError, match="Unexpected error"):
+        service.get_transition_details("PROJ-123")

--- a/tests/services/test_transitions.py
+++ b/tests/services/test_transitions.py
@@ -66,6 +66,30 @@ def test_get_transition_details_maps_screen_fields(mock_jira: MagicMock) -> None
     assert by_id["customfield_10001"].allowed_values is None
 
 
+def test_transition_forwards_fields(mock_jira: MagicMock) -> None:
+    """Screen field values must reach transition_issue."""
+    from budjira.services.transitions import TransitionService
+
+    mock_jira.transitions.return_value = [{"id": "21", "name": "Resolve"}]
+    service = TransitionService(mock_jira)
+
+    service.transition("PROJ-123", "Resolve", fields={"resolution": {"name": "Done"}})
+
+    mock_jira.transition_issue.assert_called_once_with("PROJ-123", "21", fields={"resolution": {"name": "Done"}})
+
+
+def test_transition_without_fields_sends_none(mock_jira: MagicMock) -> None:
+    """Existing behaviour is preserved when no fields are supplied."""
+    from budjira.services.transitions import TransitionService
+
+    mock_jira.transitions.return_value = [{"id": "11", "name": "Start Progress"}]
+    service = TransitionService(mock_jira)
+
+    service.transition("PROJ-123", "Start Progress")
+
+    mock_jira.transition_issue.assert_called_once_with("PROJ-123", "11", fields=None)
+
+
 def test_get_transition_details_handles_transition_without_screen(mock_jira: MagicMock) -> None:
     """A transition with no screen has no fields, not an error."""
     from budjira.services.transitions import TransitionService

--- a/tests/services/test_transitions.py
+++ b/tests/services/test_transitions.py
@@ -1,0 +1,79 @@
+# mypy: disable-error-code="attr-defined,union-attr"
+"""Tests for the transition service."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def mock_jira() -> MagicMock:
+    """Mocked jira-python client."""
+    return MagicMock()
+
+
+def test_get_transition_details_requests_screen_fields(mock_jira: MagicMock) -> None:
+    """The expand parameter is required, otherwise no field metadata comes back."""
+    from budjira.services.transitions import TransitionService
+
+    mock_jira.transitions.return_value = []
+    service = TransitionService(mock_jira)
+
+    service.get_transition_details("PROJ-123")
+
+    mock_jira.transitions.assert_called_once_with("PROJ-123", expand="transitions.fields")
+
+
+def test_get_transition_details_maps_screen_fields(mock_jira: MagicMock) -> None:
+    """Raw Jira metadata is mapped into typed models."""
+    from budjira.services.transitions import TransitionService
+
+    mock_jira.transitions.return_value = [
+        {
+            "id": "21",
+            "name": "Resolve",
+            "to": {"name": "Resolved"},
+            "fields": {
+                "resolution": {
+                    "required": True,
+                    "name": "Resolution",
+                    "schema": {"type": "resolution"},
+                    "allowedValues": [{"name": "Done"}, {"name": "Won't Do"}],
+                },
+                "customfield_10001": {
+                    "required": False,
+                    "name": "Solution details",
+                    "schema": {"type": "string"},
+                },
+            },
+        }
+    ]
+    service = TransitionService(mock_jira)
+
+    transitions = service.get_transition_details("PROJ-123")
+
+    assert len(transitions) == 1
+    assert transitions[0].id == "21"
+    assert transitions[0].to_status == "Resolved"
+
+    by_id = {f.field_id: f for f in transitions[0].fields}
+    assert by_id["resolution"].required is True
+    assert by_id["resolution"].field_type == "resolution"
+    assert by_id["resolution"].allowed_values == ["Done", "Won't Do"]
+    assert by_id["customfield_10001"].required is False
+    assert by_id["customfield_10001"].allowed_values is None
+
+
+def test_get_transition_details_handles_transition_without_screen(mock_jira: MagicMock) -> None:
+    """A transition with no screen has no fields, not an error."""
+    from budjira.services.transitions import TransitionService
+
+    mock_jira.transitions.return_value = [{"id": "11", "name": "Start Progress"}]
+    service = TransitionService(mock_jira)
+
+    transitions = service.get_transition_details("PROJ-123")
+
+    assert transitions[0].fields == []
+    assert transitions[0].to_status is None

--- a/tests/utils/test_transition_fields.py
+++ b/tests/utils/test_transition_fields.py
@@ -6,6 +6,7 @@ import pytest
 from budjira.models.transition import Transition, TransitionField
 from budjira.utils.errors import ValidationError
 from budjira.utils.transition_fields import (
+    attribute_validator_error,
     encode_field_value,
     format_field_requirements,
     missing_required_fields,
@@ -148,6 +149,68 @@ class TestMissingRequiredFields:
         missing = missing_required_fields({"resolution": {"name": "Done"}}, transition)
 
         assert all(f.field_id != "customfield_10001" for f in missing)
+
+
+class TestAttributeValidatorError:
+    """Test mapping an anonymous validator message onto a screen field."""
+
+    def test_matches_field_whose_words_appear_in_the_message(self, transition: Transition) -> None:
+        """The real-world case: Jira's wording reorders and separates the field name."""
+        field = attribute_validator_error(["Provide details about the solution made available."], transition)
+
+        assert field is not None
+        assert field.field_id == "customfield_10001"
+
+    def test_matches_verbatim_field_name(self, transition: Transition) -> None:
+        field = attribute_validator_error(["Solution details must be set"], transition)
+
+        assert field is not None
+        assert field.field_id == "customfield_10001"
+
+    def test_matching_ignores_case(self, transition: Transition) -> None:
+        field = attribute_validator_error(["SOLUTION DETAILS must be set"], transition)
+
+        assert field is not None
+        assert field.field_id == "customfield_10001"
+
+    def test_prefers_the_field_with_more_matching_words(self) -> None:
+        """A two-word field name beats a one-word one that also matches."""
+        candidates = Transition(
+            id="21",
+            name="Resolve",
+            fields=[
+                TransitionField(field_id="customfield_1", name="Details", required=False),
+                TransitionField(field_id="customfield_2", name="Solution details", required=False),
+            ],
+        )
+
+        field = attribute_validator_error(["Provide solution details"], candidates)
+
+        assert field is not None
+        assert field.field_id == "customfield_2"
+
+    def test_equally_good_candidates_are_not_guessed(self) -> None:
+        """Two fields matching equally well must not be resolved by coin flip."""
+        candidates = Transition(
+            id="21",
+            name="Resolve",
+            fields=[
+                TransitionField(field_id="customfield_1", name="Notes", required=False),
+                TransitionField(field_id="customfield_2", name="Comment", required=False),
+            ],
+        )
+
+        assert attribute_validator_error(["Notes and comment are required"], candidates) is None
+
+    def test_partial_word_overlap_does_not_match(self, transition: Transition) -> None:
+        """One word of a two-word field name is not enough."""
+        assert attribute_validator_error(["Provide a solution"], transition) is None
+
+    def test_returns_none_when_nothing_matches(self, transition: Transition) -> None:
+        assert attribute_validator_error(["Something else went wrong"], transition) is None
+
+    def test_returns_none_for_no_messages(self, transition: Transition) -> None:
+        assert attribute_validator_error([], transition) is None
 
 
 class TestFormatFieldRequirements:

--- a/tests/utils/test_transition_fields.py
+++ b/tests/utils/test_transition_fields.py
@@ -1,0 +1,162 @@
+"""Tests for transition field parsing, resolution and encoding."""
+
+from __future__ import annotations
+
+import pytest
+from budjira.models.transition import Transition, TransitionField
+from budjira.utils.errors import ValidationError
+from budjira.utils.transition_fields import (
+    encode_field_value,
+    format_field_requirements,
+    missing_required_fields,
+    parse_field_args,
+    resolve_fields,
+)
+
+
+@pytest.fixture
+def transition() -> Transition:
+    """A transition with one required option field and one optional text field."""
+    return Transition(
+        id="21",
+        name="Resolve",
+        to_status="Resolved",
+        fields=[
+            TransitionField(
+                field_id="resolution",
+                name="Resolution",
+                required=True,
+                field_type="resolution",
+                allowed_values=["Done", "Won't Do"],
+            ),
+            TransitionField(
+                field_id="customfield_10001",
+                name="Solution details",
+                required=False,
+                field_type="string",
+            ),
+        ],
+    )
+
+
+class TestParseFieldArgs:
+    """Test parsing of raw --field arguments."""
+
+    def test_parses_key_value_pairs(self) -> None:
+        assert parse_field_args(["resolution=Done"]) == {"resolution": "Done"}
+
+    def test_keeps_equals_signs_in_the_value(self) -> None:
+        assert parse_field_args(["customfield_10001=a=b"]) == {"customfield_10001": "a=b"}
+
+    def test_none_yields_empty_mapping(self) -> None:
+        assert parse_field_args(None) == {}
+
+    def test_missing_equals_is_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="key=value"):
+            parse_field_args(["resolution"])
+
+
+class TestResolveFields:
+    """Test resolution of user-supplied keys against screen metadata."""
+
+    def test_resolves_by_field_id(self, transition: Transition) -> None:
+        assert resolve_fields({"resolution": "Done"}, transition) == {"resolution": {"name": "Done"}}
+
+    def test_resolves_by_display_name_case_insensitively(self, transition: Transition) -> None:
+        resolved = resolve_fields({"solution DETAILS": "Rolled out"}, transition)
+
+        assert resolved == {"customfield_10001": "Rolled out"}
+
+    def test_optional_field_is_forwarded(self, transition: Transition) -> None:
+        """Not only required fields are sent."""
+        resolved = resolve_fields({"customfield_10001": "note"}, transition)
+
+        assert "customfield_10001" in resolved
+
+    def test_unknown_key_lists_available_fields(self, transition: Transition) -> None:
+        with pytest.raises(ValidationError) as exc:
+            resolve_fields({"nonsense": "x"}, transition)
+
+        message = str(exc.value)
+        assert "nonsense" in message
+        assert "resolution" in message
+        assert "Solution details" in message
+
+    def test_ambiguous_name_names_the_candidates(self) -> None:
+        ambiguous = Transition(
+            id="21",
+            name="Resolve",
+            fields=[
+                TransitionField(field_id="customfield_1", name="Notes", required=False),
+                TransitionField(field_id="customfield_2", name="notes", required=False),
+            ],
+        )
+
+        with pytest.raises(ValidationError, match="ambiguous"):
+            resolve_fields({"notes": "x"}, ambiguous)
+
+    def test_value_outside_allowed_values_is_rejected(self, transition: Transition) -> None:
+        with pytest.raises(ValidationError) as exc:
+            resolve_fields({"resolution": "Nope"}, transition)
+
+        assert "Done" in str(exc.value)
+
+
+class TestEncodeFieldValue:
+    """Test per-type encoding of field values."""
+
+    def test_string_stays_plain(self) -> None:
+        field = TransitionField(field_id="customfield_1", name="Notes", required=False, field_type="string")
+
+        assert encode_field_value(field, "hello") == "hello"
+
+    def test_option_is_wrapped_in_value(self) -> None:
+        field = TransitionField(field_id="customfield_1", name="Kind", required=False, field_type="option")
+
+        assert encode_field_value(field, "A") == {"value": "A"}
+
+    def test_array_is_wrapped_in_a_list(self) -> None:
+        field = TransitionField(field_id="customfield_1", name="Tags", required=False, field_type="array")
+
+        assert encode_field_value(field, "A") == [{"value": "A"}]
+
+    def test_resolution_uses_name(self) -> None:
+        field = TransitionField(field_id="resolution", name="Resolution", required=False, field_type="resolution")
+
+        assert encode_field_value(field, "Done") == {"name": "Done"}
+
+    def test_unknown_type_stays_plain(self) -> None:
+        field = TransitionField(field_id="customfield_1", name="Odd", required=False, field_type=None)
+
+        assert encode_field_value(field, "x") == "x"
+
+
+class TestMissingRequiredFields:
+    """Test detection of unsatisfied required fields."""
+
+    def test_reports_unsatisfied_required_field(self, transition: Transition) -> None:
+        missing = missing_required_fields({}, transition)
+
+        assert [f.field_id for f in missing] == ["resolution"]
+
+    def test_satisfied_required_field_is_not_reported(self, transition: Transition) -> None:
+        missing = missing_required_fields({"resolution": {"name": "Done"}}, transition)
+
+        assert missing == []
+
+    def test_optional_field_is_never_reported(self, transition: Transition) -> None:
+        missing = missing_required_fields({"resolution": {"name": "Done"}}, transition)
+
+        assert all(f.field_id != "customfield_10001" for f in missing)
+
+
+class TestFormatFieldRequirements:
+    """Test the copy-pasteable requirement listing."""
+
+    def test_lists_id_name_type_and_allowed_values(self, transition: Transition) -> None:
+        text = format_field_requirements(transition.fields)
+
+        assert "resolution" in text
+        assert "Resolution" in text
+        assert "Done" in text
+        assert "--field" in text


### PR DESCRIPTION
Implements parts 2 and 3 of #101 plus `--dry-run`. Does **not** close the issue —
parts 1 (multi-hop path finding) and 4 (ADF) remain open, see below.

Spec: `docs/superpowers/specs/2026-07-29-transition-screen-fields-design.md`
Plan: `docs/superpowers/plans/2026-07-29-transition-screen-fields.md`

## Problem

A transition whose screen carries a required field was **un-completable from the
CLI** — not degraded, impossible. `transition()` passed no fields, and
`get_transitions()` never asked for screen metadata.

## What changed

```bash
# Inspect what a transition needs, without touching the issue
budjira issue update PROJ-123 --status "Resolve" --dry-run

# Supply fields by id or by display name
budjira issue update PROJ-123 --status "Resolve" \
    --field resolution=Done \
    --field "Solution details=Rolled out"
```

- `budjira/models/transition.py` — typed `Transition` / `TransitionField`.
- `TransitionService.get_transition_details()` — requests `expand=transitions.fields`.
- `TransitionService.transition(fields=...)` — forwards values.
- `budjira/utils/transition_fields.py` — pure parse / resolve / encode / attribute
  helpers, no Jira client, so the fiddly logic is testable without mocks.
- `issue update` — `--field` (repeatable), `--dry-run`, `--interactive/--no-interactive`.

Non-interactive callers (agents, CI, piped stdin) never get a prompt: a missing
required field aborts with the field ids, types and allowed values, ready to paste
back. Prompting is gated on a `_can_prompt()` TTY check, not just the flag, because
a forgotten `--no-interactive` would otherwise hang forever.

## Two things worth a reviewer's attention

**1. Validator attribution needed the `__cause__` chain.** The service layer converts
`JIRAError` into `JiraAPIError` and keeps only the error text, so the response body
with `errorMessages` survives nowhere else. Reading `error.response` directly would
have worked in unit tests and never in production. There is a test for the wrapped
shape specifically.

**2. Matching is word-based, not substring.** Jira rarely quotes the field name:
a field called `Solution details` is reported as *"Provide details about the solution
made available."* Literal substring matching — what the spec originally described —
would never fire. Attribution now requires every significant word of the field name
to appear in the message, in any order, and returns nothing when two fields match
equally well, so Jira's own message is forwarded rather than the wrong field named.

## Value encoding

`--field resolution=Done` would fail as a plain string. `encode_field_value()` wraps
per schema type: `array` → `[{"value": v}]`, `option` → `{"value": v}`,
`resolution`/`priority` → `{"name": v}`. Other structured types pass through
untouched and surface as a Jira error rather than being silently mangled.

## Out of scope, deliberately

- **Path finding (#101 part 1)** — `GET /issue/{key}/transitions` is state-specific,
  so look-ahead needs the workflow definition, which is normally admin-gated. Needs
  a spike against a real instance first.
- **ADF (#101 part 4)** — budjira passes no `rest_api_version`, so jira-python's
  default `"2"` applies and rich-text fields accept plain strings today. This becomes
  real with Epic #96, which must then cover transition fields too.

## Incidental fixes

- Transition models used positional `Field(None, ...)`, which mypy does not treat as
  a default; switched to `Field(default=None, ...)`.
- `.claude/ai-usage-prompt.md` had been generated from a stale local
  `ai-prompt-template.toml` instead of the code defaults, so it was missing the
  `--parent` sub-task section and the sprint write-operations section. Regenerated
  from code. **The documented regeneration command is machine-dependent** — worth its
  own issue.
- Two legacy call-shape assertions in `test_jira_client.py` now include `fields=None`,
  which is jira-python's own default, so fieldless transitions behave identically.

## Tests

962 passed, 3 skipped. Coverage 86.90% overall;
`transition_fields.py` and `models/transition.py` at 100%, `services/transitions.py`
at 94%. Full pre-commit gate green.